### PR TITLE
add rustic-cargo-current-test and bind it to "C-c C-c C-c"

### DIFF
--- a/rustic.el
+++ b/rustic.el
@@ -162,6 +162,7 @@ to the function arguments.  When nil, `->' will be indented one level."
     (define-key map (kbd "C-c C-c C-r") 'rustic-cargo-run)
     (define-key map (kbd "C-c C-c C-f") 'rustic-cargo-fmt)
     (define-key map (kbd "C-c C-c C-t") 'rustic-cargo-test)
+    (define-key map (kbd "C-c C-c C-c") 'rustic-cargo-current-test)
     (define-key map (kbd "C-c C-c C-l") 'rustic-cargo-clippy)
     (define-key map (kbd "C-c C-c C-o") 'rustic-format-buffer)
 


### PR DESCRIPTION
This new command can be used to run only the test near the point.
It should work for all the cases bellow:
```
fn test_nothing() {
    assert!(false);
}

fn test_something() {
    assert!(true);
}

mod tests {
    #[test]
    fn wut_nothing() {
        assert!(false);
    }

    #[test]
    fn wut_something() {
        assert!(true);
    }
}
```

Tests will be added in the following commit.

Closes #43.