### PR TITLE
Fix playground url

### DIFF
--- a/rustic-util.el
+++ b/rustic-util.el
@@ -29,7 +29,7 @@
   :type 'function
   :group 'rustic)
 
-(defcustom rustic-playpen-url-format "https://play.rustic-lang.org/?code=%s"
+(defcustom rustic-playpen-url-format "https://play.rust-lang.org/?code=%s"
   "Format string to use when submitting code to the playpen"
   :type 'string
   :group 'rustic)


### PR DESCRIPTION
Currently it's pointing to `play.rustic-lang` which should presumably be `play.rust-lang`.