### PR TITLE
Add ability to open new project on creation. Add more docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,8 @@ The command `rustic-popup-default-action` (`RET` or `TAB`) allows you to change:
 
 Use `rustic-cargo-outdated` to get a list of dependencies that are out of date. The results 
 are displayed in `tabulated-list-mode` and you can use most commands you know from the emacs
-package menu.
+package menu. This option requires the rust package `cargo-outdated` to be
+installed before being used.
 
 - `u` mark single crate for upgrade
 - `U` mark all upgradable crates

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -15,6 +15,12 @@
   :type 'string
   :group 'rustic-cargo)
 
+(defcustom rustic-cargo-open-new-project t
+  "If t then any project created with cargo-new will be opened automatically.
+If nil then the project is simply created."
+  :type 'boolean
+  :group 'rustic-cargo)
+
 (defface rustic-cargo-outdated-upgrade-face
   '((t (:foreground "LightSeaGreen")))
   "Face used for crates marked for upgrade.")
@@ -351,17 +357,18 @@ Execute process in PATH."
 
 ;;;###autoload
 (defun rustic-cargo-new (project-path &optional bin)
-  "Run 'cargo new' to start a new package.
-If BIN is not nil, create a binary application, otherwise a library.
-"
+  "Run 'cargo new' to start a new package in the path specified by PROJECT-PATH.
+If BIN is not nil, create a binary application, otherwise a library."
   (interactive "DProject path: ")
   (let ((bin (if (or bin (y-or-n-p "Create new binary package? "))
                  "--bin"
-                 "--lib"))
+               "--lib"))
         (new-sentinel (lambda (process signal)
-                    (when (equal signal "finished\n")
-                      (message (format "Created new package: %s"
-                                       (file-name-base project-path))))))
+                        (when (equal signal "finished\n")
+                          (message (format "Created new package: %s"
+                                           (file-name-base project-path)))
+                          (if rustic-cargo-open-new-project
+                              (find-file (concat project-path "/src/main.rs"))))))
         (proc "rustic-cargo-new-process")
         (buf "*cargo-new*"))
     (make-process :name proc
@@ -378,26 +385,31 @@ If BIN is not nil, create a binary application, otherwise a library.
 
 ;;;###autoload
 (defun rustic-cargo-build ()
+  "Run 'cargo build' for the current project."
   (interactive)
   (rustic-run-cargo-command "cargo build"))
 
 ;;;###autoload
 (defun rustic-cargo-run ()
+  "Run 'cargo run' for the current project."
   (interactive)
   (rustic-run-cargo-command "cargo run"))
 
 ;;;###autoload
 (defun rustic-cargo-clean ()
+  "Run 'cargo clean' for the current project."
   (interactive)
   (rustic-run-cargo-command "cargo clean"))
 
 ;;;###autoload
 (defun rustic-cargo-check ()
+  "Run 'cargo check' for the current project."
   (interactive)
   (rustic-run-cargo-command "cargo check"))
 
 ;;;###autoload
 (defun rustic-cargo-bench ()
+  "Run 'cargo bench' for the current project."
   (interactive)
   (rustic-run-cargo-command "cargo bench"))
 

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -413,16 +413,6 @@ If BIN is not nil, create a binary application, otherwise a library."
   (interactive)
   (rustic-run-cargo-command "cargo bench"))
 
-;;;###autoload
-(defun rustic-cargo-open-dependency-file ()
-  "Open the 'Cargo.toml' file at the project root."
-  (interactive)
-  (let ((workspace (rustic-buffer-workspace t)))
-    (if workspace
-        (find-file (concat workspace "/Cargo.toml"))
-      (message "The current buffer is not inside a rust project!"))
-    )
-  )
 
 (provide 'rustic-cargo)
 ;;; rustic-cargo.el ends here

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -413,5 +413,16 @@ If BIN is not nil, create a binary application, otherwise a library."
   (interactive)
   (rustic-run-cargo-command "cargo bench"))
 
+;;;###autoload
+(defun rustic-cargo-open-dependency-file ()
+  "Open the 'Cargo.toml' file at the project root."
+  (interactive)
+  (let ((workspace (rustic-buffer-workspace t)))
+    (if workspace
+        (find-file (concat workspace "/Cargo.toml"))
+      (message "The current buffer is not inside a rust project!"))
+    )
+  )
+
 (provide 'rustic-cargo)
 ;;; rustic-cargo.el ends here

--- a/rustic-util.el
+++ b/rustic-util.el
@@ -309,5 +309,18 @@ src-block or buffer on the Rust playpen."
                               (let ((URL (read-from-minibuffer "Playpen URL: " last-line)))
                                 (browse-url URL)))))))))))
 
+
+;;;###autoload
+(defun rustic-open-dependency-file ()
+  "Open the 'Cargo.toml' file at the project root if the current buffer is 
+visiting a project."
+  (interactive)
+  (let ((workspace (rustic-buffer-workspace t)))
+    (if workspace
+        (find-file (concat workspace "/Cargo.toml"))
+      (message "The current buffer is not inside a rust project!"))
+    )
+  )
+
 (provide 'rustic-util)
 ;;; rustic-util.el ends here


### PR DESCRIPTION
- When running 'cargo new', the newly created project can now be opened
  automatically if the user specifies it via the variable
  ```rustic-cargo-open-new-project```. Its default is set to ```t```
- Add more docstrings for interactive functions which use cargo. A bit redundant
  given their name but its still good to have docstrings for all functions.
- Add a convenience command to automatically open the `Cargo.toml` file if the current buffer is visiting a rust project.