### PR TITLE
Compilation scroll output

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ Simply put `(use-package rustic)` in your config and most stuff gets configured 
 If you have `rust-mode` installed, ensure it is required before rustic since it has to be removed
 from `auto-mode-alist`. However you only need `rust-mode` if you want to use `emacs-racer`. There's some stuff that isn't included in rustic.
 
+# Compilation
+
+Rustic doesn't use `compilation-start` yet, since there seems to be no way to set `coding-system-for-read` and `utf-8-emacs-unix`. 
+
+Supported compile.el variables:
+- compilation-arguments
+- compilation-scroll-output (but not `first-error` yet)
+
 # Rustfmt
 
 You can format your code with `rustic-format-buffer` or `rustic-cargo-fmt`.
@@ -152,6 +160,15 @@ package menu.
 - `q` quit window
 
 ![](https://raw.githubusercontent.com/brotzeit/rustic/master/img/outdated.png)
+
+## Tests
+
+To run the tests, you will need [Cask](https://github.com/cask/cask).
+
+``` bash
+$ cask
+$ cask exec ert-runner
+```
 
 # Contributing
 

--- a/rustic-compile.el
+++ b/rustic-compile.el
@@ -210,8 +210,9 @@ Set environment variables for rust process."
       (unless no-mode-line
         (setq mode-line-process
               '((:propertize ":%s" face compilation-mode-line-run)
-                compilation-mode-line-errors))
-        (force-mode-line-update)))))
+                compilation-mode-line-errors)))
+      (force-mode-line-update)
+      (sit-for 0))))
 
 (defun rustic-compilation-start (command &rest args)
   "Start a compilation process with COMMAND."
@@ -221,8 +222,11 @@ Set environment variables for rust process."
         (mode (or (plist-get args :mode) 'rustic-compilation-mode))
         (directory (or (plist-get args :directory) (rustic-buffer-workspace)))
         (sentinel (or (plist-get args :sentinel) #'compilation-sentinel)))
-    (rustic-compilation-setup-buffer buf directory mode)
+    (when compilation-scroll-output
+      (rustic-compilation-setup-buffer buf directory mode))
     (funcall rustic-compile-display-method buf)
+    (unless compilation-scroll-output
+      (rustic-compilation-setup-buffer buf directory mode))
     (with-current-buffer buf
       (rustic-make-process :name process
                            :buffer buf


### PR DESCRIPTION
I'm not sure why this "works", but the cursors position seems to be correct when setting `compilation-scroll-output` to nil/t. But this is far from ideal. Maybe somebody figures out how to integrate compile.el better.