### PR TITLE
Add open/build documentation option and check for cargo outdated

### DIFF
--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -427,13 +427,16 @@ If BIN is not nil, create a binary application, otherwise a library."
 (defun rustic-cargo-build-docs ()
   "Build the documentation for the current project."
   (interactive)
-  (rustic-run-cargo-command "cargo doc"))
+  (if (y-or-n-p "Create documentation for dependencies?")
+      (rustic-run-cargo-command "cargo doc")
+    (rustic-run-cargo-command "cargo doc --no-deps"))
+  )
 
 ;;;###autoload
 (defun rustic-cargo-open-docs ()
   "Open the documentation for the current project in a browser."
   (interactive)
-  (rustic-run-cargo-command "cargo doc --open"))
+  (rustic-run-cargo-command "cargo doc --open --no-deps"))
 
 (provide 'rustic-cargo)
 ;;; rustic-cargo.el ends here

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -419,13 +419,13 @@ If BIN is not nil, create a binary application, otherwise a library."
 (defun rustic-cargo-build-docs ()
   "Build the documentation for the current project."
   (interactive)
-  (rustic-run-cargo-command "cargo docs"))
+  (rustic-run-cargo-command "cargo doc"))
 
 ;;;###autoload
 (defun rustic-cargo-open-docs ()
   "Open the documentation for the current project in a browser."
   (interactive)
-  (rustic-run-cargo-command "cargo docs --open"))
+  (rustic-run-cargo-command "cargo doc --open"))
 
 (provide 'rustic-cargo)
 ;;; rustic-cargo.el ends here

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -424,7 +424,7 @@ If BIN is not nil, create a binary application, otherwise a library."
 
 
 ;;;###autoload
-(defun rustic-cargo-build-docs ()
+(defun rustic-cargo-build-doc ()
   "Build the documentation for the current project."
   (interactive)
   (if (y-or-n-p "Create documentation for dependencies?")
@@ -433,10 +433,14 @@ If BIN is not nil, create a binary application, otherwise a library."
   )
 
 ;;;###autoload
-(defun rustic-cargo-open-docs ()
-  "Open the documentation for the current project in a browser."
+(defun rustic-cargo-doc ()
+  "Open the documentation for the current project in a browser.
+The documentation is built if necessary."
   (interactive)
-  (rustic-run-cargo-command "cargo doc --open --no-deps"))
+  (if (y-or-n-p "Open docs for dependencies as well?")
+      (rustic-run-cargo-command "cargo doc --open")
+    (rustic-run-cargo-command "cargo doc --open --no-deps"))
+  )
 
 (provide 'rustic-cargo)
 ;;; rustic-cargo.el ends here

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -388,7 +388,7 @@ If BIN is not nil, create a binary application, otherwise a library."
 ;; Interactive
 
 (defun rustic-run-cargo-command (command)
-  "Run the specifiend COMMAND with cargo."
+  "Run the specified COMMAND with cargo."
   (rustic-compilation-process-live)
   (rustic-compilation-start (split-string command)))
 

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -167,11 +167,18 @@ If ARG is not nil, use value as argument and store it in `rustic-test-arguments'
   :type 'face
   :group 'rustic)
 
+(defconst rustic-cargo-outdated-success-msg "After cargo-outdated is installed, please rerun 'rustic-cargo-outdated' again!"
+  "Message used to notify the user that they must rerun rustic-cargo-outdated after cargo-outdated has finished installing..")
+
 (defconst rustic-cargo-outdated-not-installed-warning
   "Rustic: The package cargo-outdated needs to be installed. Please install it with the command \"cargo install cargo-outdated\""
   "Warning used to let the user know that cargo-outdated is not installed.")
 
-(defconst rustic-cargo-outdated-success-msg "After cargo-outdated is installed, please rerun 'rustic-cargo-outdated' again!")
+(defconst rustic-cargo-edit-success-msg "Please run upgrade again after the cargo-edit cargo has finished installing!"
+  "Message used to notify the user know that they must rerun rustic-cargo-upgrade after cargo-edit has finished installing.")
+
+(defconst rustic-cargo-edit-not-installed-warning "The crate 'cargo-edit' is required to perform upgrades on outdated crates!"
+  "Warning used to let the user know that cargo-edit must be installed in order to upgrade crates.")
 
 (defvar rustic-cargo-outdated-process-name "rustic-cargo-outdated-process")
 
@@ -364,7 +371,9 @@ If the user agrees, install crate and show YMSG if not nil. Otherwise, show NMSG
       (setq upgrade (concat upgrade (format "%s@%s " (elt crate 0) (elt crate 2)))))
     (let ((output (shell-command-to-string (format "cargo upgrade %s" upgrade))))
       (if (string-match "error: no such subcommand:" output)
-          (rustic-cargo-install-crate-p "edit")
+          (rustic-cargo-install-crate-p "edit"
+                                        rustic-cargo-edit-success-msg
+                                        rustic-cargo-edit-not-installed-warning)
         (rustic-cargo-reload-outdated)))))
 
 ;;;;;;;;;;;;;;;;

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -380,6 +380,7 @@ If BIN is not nil, create a binary application, otherwise a library."
 ;; Interactive
 
 (defun rustic-run-cargo-command (command)
+  "Run the specifiend COMMAND with cargo."
   (rustic-compilation-process-live)
   (rustic-compilation-start (split-string command)))
 
@@ -413,6 +414,18 @@ If BIN is not nil, create a binary application, otherwise a library."
   (interactive)
   (rustic-run-cargo-command "cargo bench"))
 
+
+;;;###autoload
+(defun rustic-cargo-build-docs ()
+  "Build the documentation for the current project."
+  (interactive)
+  (rustic-run-cargo-command "cargo docs"))
+
+;;;###autoload
+(defun rustic-cargo-open-docs ()
+  "Open the documentation for the current project in a browser."
+  (interactive)
+  (rustic-run-cargo-command "cargo docs --open"))
 
 (provide 'rustic-cargo)
 ;;; rustic-cargo.el ends here

--- a/rustic-popup.el
+++ b/rustic-popup.el
@@ -19,7 +19,8 @@
     (?o "outdated" outdated)
     (?e "clean"    clean)
     (?k "check"    check)
-    (?t "test"     test))
+    (?t "test"     test)
+    (?d "doc" doc))
   "List of commands that are displayed in the popup.
 The first element of each list contains a command's binding."
   :type 'list


### PR DESCRIPTION
- Add option to open documentation/build it as well or to simply build documentation without opening it.
- Add open documentation option to popup menu
- Add an extra check for cargo-outdate. If the binary is not installed in path, rustic seems to start installing an unrelated package for me. The new check will simply display a warning and ask the user to install it.