### PR TITLE
Preview of the transient

### DIFF
--- a/rustic-transient.el
+++ b/rustic-transient.el
@@ -1,17 +1,8 @@
-;;; rustic-transient.el --- Transient based popup-*-lexical-binding: t-*-
+;;; rustic-transient.el --- Transient based popup -*-lexical-binding: t-*-
 
 ;;; Code:
 
 (require 'rustic-cargo)
-
-;;;###autoload
-(define-infix-command rustic-transient:-trace ()
-  :description "Trace level"
-  :class 'transient-switch
-  :shortarg "-t"
-  :argument "--trace-level= "
-  :choices '("0" "1" "Full"))
-
 
 (defun rustic-transient--get-args (menu)
   "Retrieve the arguments provided to the transient called MENU."
@@ -22,13 +13,28 @@
   (shell-command (concat "cargo " command " --help") "*Help-Buffer-Rustic*"))
 
 
+(define-infix-command rustic-transient:--trace ()
+  :description "Trace level"
+  :class 'transient-switches
+  :key "-t"
+  :argument-format "%s"
+  :argument-regexp "0\\|1\\|Full"
+  :choices '("0" "1" "Full"))
+
+(define-infix-command rustic--transient--new:-v ()
+  :description "Trace level"
+  :class 'transient-switches
+  :key "-t"
+  :argument-format "%s"
+  :argument-regexp "git\\|hg\\|pijul\\|fossil\\|none"
+  :choices '("git" "hg" "pijul" "fossil" "none"))
+
 (define-infix-argument rustic--transient--general:-j ()
   :description "The number of processors to use"
   :class 'transient-option
   :shortarg "-j"
   :argument "--jobs="
   )
-
 
 (define-infix-argument rustic--transient--general:-e ()
   :description "Packages to exclude"
@@ -43,7 +49,6 @@
   :shortarg "-D"
   :argument "--target-dir="
   )
-
 
 (define-infix-argument rustic--transient--general:-m ()
   :description "Packages to exclude"
@@ -193,6 +198,42 @@
 ;;;###autoload
 (defun rustic--transient-test-help ()
   (rustic--transient-help "test"))
+
+;;;###autoload
+(defun rustic--transient-check-help ()
+  (rustic--transient-help "check"))
+
+;;;###autoload
+(defun rustic--transient-clean-help ()
+  (rustic--transient-help "clean"))
+
+;;;###autoload
+(defun rustic--transient-clean-help ()
+  (rustic--transient-help "init"))
+
+;;;###autoload
+(defun rustic--transient-run-help ()
+  (rustic--transient-help "run"))
+
+;;;###autoload
+(defun rustic--transient-bench-help ()
+  (rustic--transient-help "bench"))
+
+;;;###autoload
+(defun rustic--transient-update-help ()
+  (rustic--transient-help "update"))
+
+;;;###autoload
+(defun rustic--transient-publish-help ()
+  (rustic--transient-help "publish"))
+
+;;;###autoload
+(defun rustic--transient-install-help ()
+  (rustic--transient-help "install"))
+
+;;;###autoload
+(defun rustic--transient-install-help ()
+  (rustic--transient-help "uninstall"))
 
 ;;;###autoload
 (defun test-args (&optional args)

--- a/rustic-transient.el
+++ b/rustic-transient.el
@@ -8,10 +8,91 @@
   "Retrieve the arguments provided to the transient called MENU."
   (transient-args menu))
 
+;;; Help commands
 (defun rustic--transient-help (command)
-  "Display the help menu for the cargo COMMAND from the Rustic-Transient menu."
-  (shell-command (concat "cargo " command " --help") "*Help-Buffer-Rustic*"))
+  "Display the help menu for the cargo COMMAND from the Rustic-Transient menu.
+A new buffer is created which contains the command."
+  (let ((help-buff "*Help-Buffer-Rustic*"))
+    ;; Kill help buffer if it exists
+    (if (get-buffer help-buff)
+        (kill-buffer help-buff))
+    (shell-command (concat "cargo " command " --help") help-buff)
+    (pop-to-buffer help-buff)
+    (read-only-mode)
+    (local-set-key (kbd "q") 'kill-buffer-and-window)
+    (if (package-installed-p 'evil)
+        (evil-local-set-key 'normal (kbd "q") 'kill-buffer-and-window))
+    (goto-line 1)))
 
+;;;###autoload
+(defun rustic--transient-doc-help ()
+  (interactive)
+  (rustic--transient-help "doc"))
+
+;;;###autoload
+(defun rustic--transient-build-help ()
+  (interactive)
+  (rustic--transient-help "build"))
+
+;;;###autoload
+(defun rustic--transient-new-help ()
+  (interactive)
+  (rustic--transient-help "new"))
+
+;;;###autoload
+(defun rustic--transient-test-help ()
+  (interactive)
+  (rustic--transient-help "test"))
+
+;;;###autoload
+(defun rustic--transient-check-help ()
+  (interactive)
+  (rustic--transient-help "check"))
+
+;;;###autoload
+(defun rustic--transient-clean-help ()
+  (interactive)
+  (rustic--transient-help "clean"))
+
+;;;###autoload
+(defun rustic--transient-clean-help ()
+  (interactive)
+  (rustic--transient-help "init"))
+
+;;;###autoload
+(defun rustic--transient-run-help ()
+  (interactive)
+  (rustic--transient-help "run"))
+
+;;;###autoload
+(defun rustic--transient-bench-help ()
+  (interactive)
+  (rustic--transient-help "bench"))
+
+;;;###autoload
+(defun rustic--transient-update-help ()
+  (interactive)
+  (rustic--transient-help "update"))
+
+;;;###autoload
+(defun rustic--transient-publish-help ()
+  (interactive)
+  (rustic--transient-help "publish"))
+
+;;;###autoload
+(defun rustic--transient-install-help ()
+  (interactive)
+  (rustic--transient-help "install"))
+
+;;;###autoload
+(defun rustic--transient-uninstall-help ()
+  (interactive)
+  (rustic--transient-help "uninstall"))
+
+;;;###autoload
+(defun test-args (&optional args)
+  (interactive)
+  (message "%s" (rustic-transient--get-args 'rustic--transient-doc)))
 
 (define-infix-command rustic-transient:--trace ()
   :description "Trace level"
@@ -156,7 +237,11 @@
      ("-O" "Run without accessing the network" ("-O" "--offline"))
      ("-q" "Run command without output buffer" ("-q" "--quiet"))
      ("-V" "Verbose" ("-v" "--verbose"))
-     ]]
+     ]
+   ["Commands"
+    ("H" "Help" rustic--transient-new-help)
+    ]
+   ]
   )
 
 ;;;###autoload
@@ -164,7 +249,7 @@
   "Rustic Cargo Commands"
   [
    ["Quick Commands"
-    (rustic-transient:-trace)
+    (rustic-transient:--trace)
     ("b" "Build" rustic-cargo-build)
     ("f" "Format" rustic-cargo-fmt)
     ("r" "Run" rustic-cargo-run)
@@ -181,71 +266,12 @@
     ]
    ])
 
-
-;;;###autoload
-(defun rustic--transient-doc-help ()
-  (interactive)
-  (rustic--transient-help "doc"))
-
-;;;###autoload
-(defun rustic--transient-build-help ()
-  (rustic--transient-help "build"))
-
-;;;###autoload
-(defun rustic--transient-new-help ()
-  (rustic--transient-help "new"))
-
-;;;###autoload
-(defun rustic--transient-test-help ()
-  (rustic--transient-help "test"))
-
-;;;###autoload
-(defun rustic--transient-check-help ()
-  (rustic--transient-help "check"))
-
-;;;###autoload
-(defun rustic--transient-clean-help ()
-  (rustic--transient-help "clean"))
-
-;;;###autoload
-(defun rustic--transient-clean-help ()
-  (rustic--transient-help "init"))
-
-;;;###autoload
-(defun rustic--transient-run-help ()
-  (rustic--transient-help "run"))
-
-;;;###autoload
-(defun rustic--transient-bench-help ()
-  (rustic--transient-help "bench"))
-
-;;;###autoload
-(defun rustic--transient-update-help ()
-  (rustic--transient-help "update"))
-
-;;;###autoload
-(defun rustic--transient-publish-help ()
-  (rustic--transient-help "publish"))
-
-;;;###autoload
-(defun rustic--transient-install-help ()
-  (rustic--transient-help "install"))
-
-;;;###autoload
-(defun rustic--transient-install-help ()
-  (rustic--transient-help "uninstall"))
-
-;;;###autoload
-(defun test-args (&optional args)
-  (interactive)
-  (message "%s" (rustic-transient--get-args 'rustic--transient-doc)))
-
-;; (transient )
 (defun rustic--transient-popup ()
   "Invoke the rustic transient popup."
   (interactive)
   (rustic--transient-general-menu))
 
 (rustic--transient-general-menu)
+
 (provide 'rustic-transient)
 ;;; rustic-transient.el ends here

--- a/rustic-transient.el
+++ b/rustic-transient.el
@@ -4,28 +4,79 @@
 
 (require 'rustic-cargo)
 
-;; Load the transient popup only if transient itself is instaled
-(if (package-installed-p 'transient)
-    (define-transient-command rustic-mode--transient-menu ()
-      "Rustic Commands"
-      [["Cargo commands"
-        ("b" "Build" rustic-cargo-build)
-        ("f" "Format" rustic-cargo-fmt)
-        ("r" "Run" rustic-cargo-run)
-        ("c" "Clippy" rustic-cargo-clippy)
-        ("o" "Outdated" rustic-cargo-outdated)
-        ("e" "Clean" rustic-cargo-clean)
-        ("k" "Check" rustic-cargo-check)
-        ("t" "Test" rustic-cargo-test)
-        ("q" "Quit" transient-quit-one)
-        ]])
-  )
+(defun rustic--transient-help (command)
+  "Display the help menu for the cargo COMMAND from the Rustic-Transient menu."
+  (shell-command (concat "cargo " command " --help") "*Help-Buffer-Rustic*"))
 
+(defvar trace-me nil "Trace level")
+
+(defclass rustic--trace-var (transient-variable)
+  ((scope :initarg :scope)))
+
+(define-infix-command rustic-transient:-trace ()
+  :description "Trace level"
+  :class 'transient-switch
+  :key "-t"
+  :shortarg "-t"
+  :argument "--trace-level= "
+  ;; :variable 'trace-me
+  :choices '("0" "1" "Full"))
+
+(defun rustic-transient--get-args (menu)
+  "Retrieve the arguments provided to the transient called MENU."
+  (transient-args menu))
+
+;; Load the transient popup only if transient itself is instaled
+(define-transient-command general-menu ()
+  "Rustic Cargo Commands"
+  [
+   ["Quick Commands"
+    (rustic-transient:-trace)
+    ("b" "Build" rustic-cargo-build)
+    ("f" "Format" rustic-cargo-fmt)
+    ("r" "Run" rustic-cargo-run)
+    ("c" "Clippy" rustic-cargo-clippy)
+    ("o" "Outdated" rustic-cargo-outdated)
+    ("e" "Clean" rustic-cargo-clean)
+    ("k" "Check" rustic-cargo-check)
+    ("t" "Test" rustic-cargo-test)
+    ]
+   ["Cargo Menus"
+    ]
+   ])
+
+(define-transient-command doc-menu
+  "Rustic Cargo Doc Commands"
+  [["Arguments"
+    ("-q" "Run command without output buffer" ("-q" "--quiet"))
+    ("-o" "Open doc" ("-o" "--open"))
+    ("-a" "Build all docs" ("-a" "--all"))
+    ("-d" "Document private items" ("-e" "--document-private-items"))
+    ("-l" "Document Only this package's library" ("-l"
+                                                  "--document-private-items"))
+    ("-b" "Document all binaries" ("-b" "--bins"))
+    ("-r" "Build artifacts in release mode" ("-r" "--release"))
+    ("-A" "All features" ("-A" "--all-features"))
+    ("-n" "No default features" ("-n" "--no-default-features"))
+    ("-v" "Verbose" ("-v" "--verbose"))
+    ("-f" "Require Cargo.lock and cache to be up to date" ("-f" "--frozen"))
+    ("-O" "Run without accessing the network" ("-O" "--offline"))
+    ]
+   ["Make Docs"
+    ("b" "Build docs" test-func-arg)
+    ("H" "Help" 'rustic--transient-help)
+    ]
+   ])
+
+
+(doc-menu)
+
+;; (transient )
 (defun rustic--transient-popup ()
   "Invoke the rustic transient popup."
   (interactive)
   (rustic-mode--transient))
 
-(rustic-mode--transient)
 (provide 'rustic-transient)
 ;;; rustic-transient.el ends here
+

--- a/rustic-transient.el
+++ b/rustic-transient.el
@@ -536,7 +536,5 @@ A new buffer is created which contains the command."
   (interactive)
   (rustic--transient-general-menu))
 
-(rustic--transient-general-menu)
-
 (provide 'rustic-transient)
 ;;; rustic-transient.el ends here

--- a/rustic-transient.el
+++ b/rustic-transient.el
@@ -221,37 +221,46 @@ A new buffer is created which contains the command."
 ;;;###autoload
 (define-transient-command rustic--transient-doc ()
   "Rustic Cargo Doc Commands"
-  [["Arguments"
-    (rustic--transient--doc:-F)
-    ("-q" "Run quietly" ("-q" "--quiet"))
+  [
+   ["Documentation And Packages"
     ("-o" "Open doc" ("-o" "--open"))
+    ("-N" "No dependiencies" ("-N" "--no-deps"))
+    ("-d" "Document private items" ("-e" "--document-private-items"))
     (rustic--transient--doc:-p)
     ("-a" "Build all docs" ("-a" "--all"))
     (rustic--transient--general:-e)
-    ("-N" "No dependiencies" ("-N" "--no-deps"))
-    ("-d" "Document private items" ("-e" "--document-private-items"))
-    (rustic--transient--general:-j)
-    ("-L" "Document Only this package's library" ("-l"
-                                                  "--document-private-items"))
+    ]
+   ["Targets And Features"
     ("-l" "Document only this package's library" ("-l" "--lib"))
     (rustic--transient--doc:-b)
     ("-b" "Document all binaries" ("-b" "--bins"))
-    ("-r" "Build artifacts in release mode" ("-r" "--release"))
     ("-A" "All features" ("-A" "--all-features"))
     ("-n" "No default features" ("-n" "--no-default-features"))
-    (rustic--transient--general:-m)
+    (rustic--transient--doc:-F)
+    ]
+   ]
+  [
+   ["Display"
+    ("-q" "Run quietly" ("-q" "--quiet"))
+    ("-V" "Verbose" ("-v" "--verbose"))
+    (rustic--transient--general:-j)
     (rustic--transient--general:-D)
     (rustic--transient--general:-k)
-    ("-V" "Verbose" ("-v" "--verbose"))
+    ]
+   ["Compilation and Manifest"
+    ("-r" "Build artifacts in release mode" ("-r" "--release"))
+    (rustic--transient--general:-m)
     ("-M" "Require Cargo.lock is up to date" ("-M" "--locked"))
     ("-f" "Require Cargo.lock and cache to be up to date" ("-f" "--frozen"))
     ("-O" "Run without accessing the network" ("-O" "--offline"))
     ]
-   ["Make Docs"
-    ("b" "Build docs" test-args)
-    ("H" "Help" rustic--transient-doc-help)
-    ]
-   ])
+   ]
+  ["Make Docs"
+   ("b" "Build docs" test-args)
+   ("B" "Build docs default" test-args)
+   ("H" "Help" rustic--transient-doc-help)
+   ]
+  )
 
 (define-infix-argument rustic--transient--clean:-D ()
   :description "Directory for all generated artifacts"

--- a/rustic-transient.el
+++ b/rustic-transient.el
@@ -1,0 +1,31 @@
+;;; rustic-transient.el --- Transient based popup-*-lexical-binding: t-*-
+
+;;; Code:
+
+(require 'rustic-cargo)
+
+;; Load the transient popup only if transient itself is instaled
+(if (package-installed-p 'transient)
+    (define-transient-command rustic-mode--transient-menu ()
+      "Rustic Commands"
+      [["Cargo commands"
+        ("b" "Build" rustic-cargo-build)
+        ("f" "Format" rustic-cargo-fmt)
+        ("r" "Run" rustic-cargo-run)
+        ("c" "Clippy" rustic-cargo-clippy)
+        ("o" "Outdated" rustic-cargo-outdated)
+        ("e" "Clean" rustic-cargo-clean)
+        ("k" "Check" rustic-cargo-check)
+        ("t" "Test" rustic-cargo-test)
+        ("q" "Quit" transient-quit-one)
+        ]])
+  )
+
+(defun rustic--transient-popup ()
+  "Invoke the rustic transient popup."
+  (interactive)
+  (rustic-mode--transient))
+
+(rustic-mode--transient)
+(provide 'rustic-transient)
+;;; rustic-transient.el ends here

--- a/rustic-transient.el
+++ b/rustic-transient.el
@@ -407,6 +407,62 @@ A new buffer is created which contains the command."
    ]
   )
 
+
+(define-infix-argument rustic--transient--bench:-D ()
+  :description "Directory for all generated artifacts"
+  :class 'transient-option
+  :shortarg "-D"
+  :argument "--target-dir="
+  )
+
+(define-infix-argument rustic--transient--bench:-k ()
+  :description "Build for the target triple"
+  :class 'transient-option
+  :shortarg "-k"
+  :argument "--target="
+  )
+
+(define-infix-argument rustic--transient--bench:-b ()
+  :description "Benchmark only the specified binary"
+  :class 'transient-option
+  :shortarg "-B"
+  :argument "--bin="
+  )
+
+(define-infix-argument rustic--transient--bench:-p ()
+  :description "Package to run benchmarks fro"
+  :class 'transient-option
+  :shortarg "-p"
+  :argument "--package="
+  )
+
+(define-infix-argument rustic--transient--bench:-e ()
+  :description "Benchmark only the specified example"
+  :class 'transient-option
+  :shortarg "-e"
+  :argument "--example="
+  )
+;;;###autoload
+(define-transient-command rustic--transient-bench ()
+  "Rustic Cargo Bench Menu"
+  [
+   ["Arguments"
+    (rustic--transient--bench:-D)
+    (rustic--transient--bench:-e)
+    (rustic--transient--bench:-k)
+    (rustic--transient--bench:-p)
+    (rustic--transient--bench:-b)
+    ("-q" "Run quietly" ("-q" "--quiet"))
+    ("-V" "Verbose" ("-v" "--verbose"))
+    ("-f" "Require Cargo.lock and cache to be up to date" ("-f" "--frozen"))
+    ("-O" "Run without accessing the network" ("-O" "--offline"))
+    ("-b" "Benchmark all binaries" ("-b" "--bins"))
+    ("-l" "Benchmark only this package's library" ("-l" "--lib"))
+    ("-A" "All features" ("-A" "--all-features"))
+    ("-n" "No default features" ("-n" "--no-default-features"))
+    ]
+   ])
+
 ;;;###autoload
 (define-transient-command rustic--transient-test ()
   "Rustic Cargo Test Menu"

--- a/rustic-transient.el
+++ b/rustic-transient.el
@@ -43,6 +43,11 @@ A new buffer is created which contains the command."
         (evil-local-set-key 'normal (kbd "q") 'kill-buffer-and-window))
     (goto-line 1)))
 
+(defun rustic--transient-get-version ()
+  (interactive)
+  "Retrieve information about the version of cargo and display in minibuffer."
+  (message (shell-command-to-string "cargo --version")))
+
 ;;;###autoload
 (defun rustic--transient-doc-help ()
   (interactive)
@@ -195,8 +200,12 @@ A new buffer is created which contains the command."
     ("N" "New" rustic--transient-new)
     ("C" "Clean" rustic--transient-clean)
     ("T" "Test" rustic--transient-test)
+    ("B" "Bench" rustic--transient-bench)
     ]
-   ])
+   ["Misc"
+    ("V" "Version" rustic--transient-get-version)]
+   ]
+  )
 
 (define-infix-argument rustic--transient--doc:-F ()
   :description "Space separated list of features to activate"
@@ -344,21 +353,24 @@ A new buffer is created which contains the command."
 ;;;###autoload
 (define-transient-command rustic--transient-new ()
   "Transient for cargo new command"
-  [[ "Options"
-     (rustic--transient--new:-e)
-     (rustic--transient--new:-n)
-     (rustic--transient--new:-r)
-     (rustic--transient--new:-v)
-     ("-b" "Use a binary template(DEFAULT)" ("-b" "--bin"))
-     ("-l" "Use a library template" ("-l" "--lib"))
-     ("-f" "Require Cargo.lock and cache to be up to date" ("-f" "--frozen"))
-     ("-O" "Run without accessing the network" ("-O" "--offline"))
-     ("-q" "Run command without output buffer" ("-q" "--quiet"))
-     ("-V" "Verbose" ("-v" "--verbose"))
-     ]
-   ["Commands"
-    ("H" "Help" rustic--transient-new-help)
+  [ "New Options"
+    (rustic--transient--new:-e)
+    (rustic--transient--new:-n)
+    (rustic--transient--new:-r)
+    (rustic--transient--new:-v)
+    ("-b" "Use a binary template(DEFAULT)" ("-b" "--bin"))
+    ("-l" "Use a library template" ("-l" "--lib"))
     ]
+  ["Manifest"
+   ("-f" "Require Cargo.lock and cache to be up to date" ("-f" "--frozen"))
+   ("-O" "Run without accessing the network" ("-O" "--offline"))
+   ]
+  ["Display"
+   ("-q" "Run command without output buffer" ("-q" "--quiet"))
+   ("-V" "Verbose" ("-v" "--verbose"))
+   ]
+  ["Commands"
+   ("H" "Help" rustic--transient-new-help)
    ]
   )
 
@@ -402,24 +414,22 @@ A new buffer is created which contains the command."
 (define-transient-command rustic--transient-run ()
   "Rustic Cargo Run Menu"
   ["Arguments"
-   [
-    ("-q" "Run quietly" ("-q" "--quiet"))
-    ("-r" "Clean release artifacts" ("-r" "--release"))
-    (rustic--transient--general:-m)
-    (rustic--transient--general:-F)
-    (rustic--transient--general:-j)
-    (rustic--transient--run:-D)
-    (rustic--transient--run:-b)
-    (rustic--transient--run:-e)
-    (rustic--transient--run:-k)
-    (rustic--transient--run:-p)
-    ("-A" "All features" ("-A" "--all-features"))
-    ("-n" "No default features" ("-n" "--no-default-features"))
-    ("-V" "Verbose" ("-v" "--verbose"))
-    ("-f" "Require Cargo.lock and cache to be up to date" ("-f" "--frozen"))
-    ("-P" "Require Cargo.lock to be up to date" ("-P" "--locked"))
-    ("-O" "Run without accessing the network" ("-O" "--offline"))
-    ]
+   ("-q" "Run quietly" ("-q" "--quiet"))
+   ("-r" "Clean release artifacts" ("-r" "--release"))
+   (rustic--transient--general:-m)
+   (rustic--transient--general:-F)
+   (rustic--transient--general:-j)
+   (rustic--transient--run:-D)
+   (rustic--transient--run:-b)
+   (rustic--transient--run:-e)
+   (rustic--transient--run:-k)
+   (rustic--transient--run:-p)
+   ("-A" "All features" ("-A" "--all-features"))
+   ("-n" "No default features" ("-n" "--no-default-features"))
+   ("-V" "Verbose" ("-v" "--verbose"))
+   ("-f" "Require Cargo.lock and cache to be up to date" ("-f" "--frozen"))
+   ("-P" "Require Cargo.lock to be up to date" ("-P" "--locked"))
+   ("-O" "Run without accessing the network" ("-O" "--offline"))
    ]
   )
 

--- a/rustic-transient.el
+++ b/rustic-transient.el
@@ -4,28 +4,31 @@
 
 (require 'rustic-cargo)
 
-;; (defun rustic-transient--get-args (menu)
-;;   "Retrieve the arguments provided to the transient called MENU."
-;;   (let ((t-args (transient-args menu))
-;;         (split-args '())
-;;         (curr-split-arg ""))
-;;     (dolist (elem t-args)
-;;       (if (string-match "^--[[:alnum:]]+=" elem)
-;;           (setq split-args (push split-args))
-;;         (setq split-args (push elem split-args))
-;;         )
-;;       )
-;;     )
-;;   (transient-args menu))
 
 (defun rustic-transient--get-args (menu)
   "Retrieve the arguments"
   (transient-args menu))
 
-;; (string-match "^--[[:alnum:]]+=" "--helloworld=abcfasfsa")
-;; (dolist (el
-;;          (split-string "--helloworld=onetwo" "="))
-;;   (message el))
+(defun rustic-transient--split-args (menu)
+  (let ((rustic-transient-args '("-abc" "--qeb=afs" "--anothertest=fasfsa fsa FASF"))
+        (single-dash '())
+        (double-dash '())
+        (current-split))
+    (dolist (arg rustic-transient-args)
+      (if (string-match "^--[[:alnum:]]+=" arg)
+          (progn
+            (setq current-split (split-string arg "="))
+            (setq double-dash (push (mapconcat 'identity (cdr current-split) " ") double-dash))
+            (setq double-dash (push (car current-split) double-dash))
+            )
+        (setq single-dash (push arg single-dash))
+        )
+      )
+    (message "Single %s" single-dash)
+    (message " Double %s" double-dash)
+    )
+  )
+
 
 ;;; Help commands
 (defun rustic--transient-help (command)

--- a/rustic-transient.el
+++ b/rustic-transient.el
@@ -4,14 +4,7 @@
 
 (require 'rustic-cargo)
 
-(defun rustic--transient-help (command)
-  "Display the help menu for the cargo COMMAND from the Rustic-Transient menu."
-  (shell-command (concat "cargo " command " --help") "*Help-Buffer-Rustic*"))
-
 (defvar trace-me nil "Trace level")
-
-(defclass rustic--trace-var (transient-variable)
-  ((scope :initarg :scope)))
 
 (define-infix-command rustic-transient:-trace ()
   :description "Trace level"
@@ -25,6 +18,11 @@
 (defun rustic-transient--get-args (menu)
   "Retrieve the arguments provided to the transient called MENU."
   (transient-args menu))
+
+(defun rustic--transient-help (command)
+  "Display the help menu for the cargo COMMAND from the Rustic-Transient menu."
+  (shell-command (concat "cargo " command " --help") "*Help-Buffer-Rustic*"))
+
 
 ;; Load the transient popup only if transient itself is instaled
 (define-transient-command general-menu ()
@@ -58,19 +56,44 @@
     ("-r" "Build artifacts in release mode" ("-r" "--release"))
     ("-A" "All features" ("-A" "--all-features"))
     ("-n" "No default features" ("-n" "--no-default-features"))
-    ("-v" "Verbose" ("-v" "--verbose"))
+    ("-V" "Verbose" ("-v" "--verbose"))
     ("-f" "Require Cargo.lock and cache to be up to date" ("-f" "--frozen"))
     ("-O" "Run without accessing the network" ("-O" "--offline"))
     ]
    ["Make Docs"
     ("b" "Build docs" test-func-arg)
-    ("H" "Help" 'rustic--transient-help)
+    ("H" "Help" rustic--transient-doc-help)
     ]
    ])
 
+(define-transient-command rustic--transient-new ()
+  "Transient for cargo new command"
+  [[ "Options"
+     ("-q" "Run command without output buffer" ("-q" "--quiet"))
+     ("-V" "Verbose" ("-v" "--verbose"))
+     ("-f" "Require Cargo.lock and cache to be up to date" ("-f" "--frozen"))
+     ("-O" "Run without accessing the network" ("-O" "--offline"))
+     ]]
+  )
+
+;;;###autoload
+(defun rustic--transient-doc-help ()
+  (interactive)
+  (rustic--transient-help "doc"))
+
+;;;###autoload
+(defun rustic--transient-build-help ()
+  (rustic--transient-help "build"))
+
+;;;###autoload
+(defun rustic--transient-new-help ()
+  (rustic--transient-help "new"))
+
+;;;###autoload
+(defun rustic--transient-test-help ()
+  (rustic--transient-help "test"))
 
 (doc-menu)
-
 ;; (transient )
 (defun rustic--transient-popup ()
   "Invoke the rustic transient popup."

--- a/rustic-transient.el
+++ b/rustic-transient.el
@@ -89,6 +89,11 @@ A new buffer is created which contains the command."
   (interactive)
   (rustic--transient-help "uninstall"))
 
+;;;###autoload
+(defun rustic--transient-cargo-help ()
+  (interactive)
+  (rustic--transient-help ""))
+
 (defun test-args (&optional args)
   (interactive)
   (message "%s" (rustic-transient--get-args 'rustic--transient-doc)))
@@ -101,8 +106,8 @@ A new buffer is created which contains the command."
   :argument-regexp "0\\|1\\|Full"
   :choices '("0" "1" "Full"))
 
-(define-infix-command rustic--transient--new:-v ()
-  :description "Trace level"
+(define-infix-command rustic--transient--general:-v ()
+  :description "Version control system to be used"
   :class 'transient-switches
   :key "-t"
   :argument-format "%s"
@@ -128,6 +133,13 @@ A new buffer is created which contains the command."
   :class 'transient-option
   :shortarg "-D"
   :argument "--target-dir="
+  )
+
+(define-infix-argument rustic--transient--general:-k ()
+  :description "Build for the target triple"
+  :class 'transient-option
+  :shortarg "-k"
+  :argument "--target="
   )
 
 (define-infix-argument rustic--transient--general:-m ()
@@ -184,25 +196,28 @@ A new buffer is created which contains the command."
 (define-transient-command rustic--transient-doc ()
   "Rustic Cargo Doc Commands"
   [["Arguments"
-    (rustic--transient--doc:-b)
-    (rustic--transient--doc:-p)
     (rustic--transient--doc:-F)
-    (rustic--transient--general:-m)
-    (rustic--transient--general:-D)
-    (rustic--transient--general:-e)
-    (rustic--transient--general:-j)
     ("-q" "Run quietly" ("-q" "--quiet"))
     ("-o" "Open doc" ("-o" "--open"))
+    (rustic--transient--doc:-p)
     ("-a" "Build all docs" ("-a" "--all"))
+    (rustic--transient--general:-e)
     ("-N" "No dependiencies" ("-N" "--no-deps"))
     ("-d" "Document private items" ("-e" "--document-private-items"))
-    ("-l" "Document Only this package's library" ("-l"
+    (rustic--transient--general:-j)
+    ("-L" "Document Only this package's library" ("-l"
                                                   "--document-private-items"))
+    ("-l" "Document only this package's library" ("-l" "--lib"))
+    (rustic--transient--doc:-b)
     ("-b" "Document all binaries" ("-b" "--bins"))
     ("-r" "Build artifacts in release mode" ("-r" "--release"))
     ("-A" "All features" ("-A" "--all-features"))
     ("-n" "No default features" ("-n" "--no-default-features"))
+    (rustic--transient--general:-m)
+    (rustic--transient--general:-D)
+    (rustic--transient--general:-k)
     ("-V" "Verbose" ("-v" "--verbose"))
+    ("-M" "Require Cargo.lock is up to date" ("-M" "--locked"))
     ("-f" "Require Cargo.lock and cache to be up to date" ("-f" "--frozen"))
     ("-O" "Run without accessing the network" ("-O" "--offline"))
     ]

--- a/rustic-transient.el
+++ b/rustic-transient.el
@@ -66,6 +66,34 @@
   :argument "--package="
   )
 
+(define-infix-argument rustic--transient--new:-r ()
+  :description "Package to document"
+  :class 'transient-option
+  :shortarg "-r"
+  :argument "--registry= "
+  )
+
+(define-infix-argument rustic--transient--new:-e ()
+  :description "Edition of the package"
+  :class 'transient-switch
+  :shortarg "-e"
+  :argument "--edition= "
+  )
+
+(define-infix-argument rustic--transient--new:-n ()
+  :description "Name of the new package"
+  :class 'transient-switch
+  :shortarg "-n"
+  :argument "--name= "
+  )
+
+(define-infix-command rustic--transient--new:-v ()
+  :description "Version control system to be used"
+  :class 'transient-switch
+  :shortarg "-v"
+  :argument "--vcs="
+  :choices '("git" "hg" "pijul" "fossil" "none"))
+
 ;;;###autoload
 (define-transient-command rustic--transient-doc ()
   "Rustic Cargo Doc Commands"
@@ -88,8 +116,24 @@
     ("-O" "Run without accessing the network" ("-O" "--offline"))
     ]
    ["Make Docs"
-    ("b" "Build docs" rustic-cargo-build)
+    ("b" "Build docs" test-args)
     ("H" "Help" rustic--transient-doc-help)
+    ]
+   ])
+
+;;;###autoload
+(define-transient-command rustic--transient-test ()
+  "Rustic Cargo Test Menu"
+  [
+   ["Arguments"
+    ("-q" "Run quietly" ("-q" "--quiet"))
+    ("-V" "Verbose" ("-v" "--verbose"))
+    ("-f" "Require Cargo.lock and cache to be up to date" ("-f" "--frozen"))
+    ("-O" "Run without accessing the network" ("-O" "--offline"))
+    ("-b" "Document all binaries" ("-b" "--bins"))
+    ("-l" "Use a library template" ("-l" "--lib"))
+    ("-A" "All features" ("-A" "--all-features"))
+    ("-n" "No default features" ("-n" "--no-default-features"))
     ]
    ])
 
@@ -97,6 +141,10 @@
 (define-transient-command rustic--transient-new ()
   "Transient for cargo new command"
   [[ "Options"
+     (rustic--transient--new:-e)
+     (rustic--transient--new:-n)
+     (rustic--transient--new:-r)
+     (rustic--transient--new:-v)
      ("-b" "Use a binary template(DEFAULT)" ("-b" "--bin"))
      ("-l" "Use a library template" ("-l" "--lib"))
      ("-f" "Require Cargo.lock and cache to be up to date" ("-f" "--frozen"))
@@ -124,6 +172,7 @@
    ["Advanced Cargo Menus"
     ("D" "Doc" rustic--transient-doc)
     ("N" "New" rustic--transient-new)
+    ("T" "Test" rustic--transient-test)
     ]
    ])
 
@@ -144,6 +193,11 @@
 ;;;###autoload
 (defun rustic--transient-test-help ()
   (rustic--transient-help "test"))
+
+;;;###autoload
+(defun test-args (&optional args)
+  (interactive)
+  (message "%s" (rustic-transient--get-args 'rustic--transient-doc)))
 
 ;; (transient )
 (defun rustic--transient-popup ()

--- a/rustic-transient.el
+++ b/rustic-transient.el
@@ -4,9 +4,28 @@
 
 (require 'rustic-cargo)
 
+;; (defun rustic-transient--get-args (menu)
+;;   "Retrieve the arguments provided to the transient called MENU."
+;;   (let ((t-args (transient-args menu))
+;;         (split-args '())
+;;         (curr-split-arg ""))
+;;     (dolist (elem t-args)
+;;       (if (string-match "^--[[:alnum:]]+=" elem)
+;;           (setq split-args (push split-args))
+;;         (setq split-args (push elem split-args))
+;;         )
+;;       )
+;;     )
+;;   (transient-args menu))
+
 (defun rustic-transient--get-args (menu)
-  "Retrieve the arguments provided to the transient called MENU."
+  "Retrieve the arguments"
   (transient-args menu))
+
+;; (string-match "^--[[:alnum:]]+=" "--helloworld=abcfasfsa")
+;; (dolist (el
+;;          (split-string "--helloworld=onetwo" "="))
+;;   (message el))
 
 ;;; Help commands
 (defun rustic--transient-help (command)
@@ -149,6 +168,13 @@ A new buffer is created which contains the command."
   :argument "--manifest-path="
   )
 
+(define-infix-argument rustic--transient--general:-F ()
+  :description "Space separated list of features to activate"
+  :class 'transient-option
+  :shortarg "-F"
+  :argument "--features="
+  )
+
 ;;;###autoload
 (define-transient-command rustic--transient-general-menu ()
   "Rustic Cargo Commands"
@@ -241,6 +267,13 @@ A new buffer is created which contains the command."
   :argument "--package="
   )
 
+(define-infix-argument rustic--transient--clean:-k ()
+  :description "Target triple to clean output for"
+  :class 'transient-option
+  :shortarg "-k"
+  :argument "--target="
+  )
+
 ;;;###autoload
 (define-transient-command rustic--transient-clean ()
   "Rustic Cargo Clean Menu"
@@ -250,6 +283,7 @@ A new buffer is created which contains the command."
     (rustic--transient--clean:-p)
     (rustic--transient--general:-m)
     (rustic--transient--clean:-D)
+    (rustic--transient--clean:-k)
     ("-r" "Clean release artifacts" ("-r" "--release"))
     ("-d" "Clean just the documentation directory" ("-d" "--doc"))
     ("-V" "Verbose" ("-v" "--verbose"))
@@ -257,6 +291,9 @@ A new buffer is created which contains the command."
     ("-P" "Require Cargo.lock to be up to date" ("-P" "--locked"))
     ("-O" "Run without accessing the network" ("-O" "--offline"))
     ]
+   ]
+  ["Commands"
+   ("H" "Help" rustic--transient-clean-help)
    ]
   )
 
@@ -309,6 +346,42 @@ A new buffer is created which contains the command."
    ]
   )
 
+(define-infix-argument rustic--transient--run:-D ()
+  :description "Directory for all generated artifacts"
+  :class 'transient-option
+  :shortarg "-D"
+  :argument "--target-dir="
+  )
+
+(define-infix-argument rustic--transient--run:-k ()
+  :description "Build for the target triple"
+  :class 'transient-option
+  :shortarg "-k"
+  :argument "--target="
+  )
+
+(define-infix-argument rustic--transient--run:-b ()
+  :description "Name of the bin target to run"
+  :class 'transient-option
+  :shortarg "-B"
+  :argument "--bin="
+  )
+
+(define-infix-argument rustic--transient--run:-p ()
+  :description "Package with the target to run"
+  :class 'transient-option
+  :shortarg "-p"
+  :argument "--package="
+  )
+
+(define-infix-argument rustic--transient--run:-e ()
+  :description "Name of the example target to run"
+  :class 'transient-option
+  :shortarg "-e"
+  :argument "--example="
+  )
+
+
 ;;;###autoload
 (define-transient-command rustic--transient-run ()
   "Rustic Cargo Run Menu"
@@ -317,7 +390,13 @@ A new buffer is created which contains the command."
     ("-q" "Run quietly" ("-q" "--quiet"))
     ("-r" "Clean release artifacts" ("-r" "--release"))
     (rustic--transient--general:-m)
+    (rustic--transient--general:-F)
     (rustic--transient--general:-j)
+    (rustic--transient--run:-D)
+    (rustic--transient--run:-b)
+    (rustic--transient--run:-e)
+    (rustic--transient--run:-k)
+    (rustic--transient--run:-p)
     ("-A" "All features" ("-A" "--all-features"))
     ("-n" "No default features" ("-n" "--no-default-features"))
     ("-V" "Verbose" ("-v" "--verbose"))

--- a/rustic-transient.el
+++ b/rustic-transient.el
@@ -22,32 +22,58 @@
   (shell-command (concat "cargo " command " --help") "*Help-Buffer-Rustic*"))
 
 
-;;;###autoload
-(define-transient-command general-menu ()
-  "Rustic Cargo Commands"
-  [
-   ["Quick Commands"
-    (rustic-transient:-trace)
-    ("b" "Build" rustic-cargo-build)
-    ("f" "Format" rustic-cargo-fmt)
-    ("r" "Run" rustic-cargo-run)
-    ("c" "Clippy" rustic-cargo-clippy)
-    ("o" "Outdated" rustic-cargo-outdated)
-    ("e" "Clean" rustic-cargo-clean)
-    ("k" "Check" rustic-cargo-check)
-    ("t" "Test" rustic-cargo-test)
-    ]
-   ["Advanced Cargo Menus"
-    ("D" "Doc" rustic--transient-doc-menu)
-    ("N" "New" rustic--transient-new-menu)
-    ]
-   ])
+(define-infix-argument rustic--transient--general:-j ()
+  :description "The number of processors to use"
+  :class 'transient-option
+  :shortarg "-j"
+  :argument "--jobs="
+  )
+
+
+(define-infix-argument rustic--transient--general:-e ()
+  :description "Packages to exclude"
+  :class 'transient-option
+  :shortarg "-e"
+  :argument "--exclude="
+  )
+
+(define-infix-argument rustic--transient--general:-D ()
+  :description "Packages to exclude"
+  :class 'transient-option
+  :shortarg "-D"
+  :argument "--target-dir="
+  )
+
+
+(define-infix-argument rustic--transient--general:-m ()
+  :description "Packages to exclude"
+  :class 'transient-option
+  :shortarg "-m"
+  :argument "--manifest-path="
+  )
+
+(define-infix-argument rustic--transient--doc:-b ()
+  :description "Packages to exclude"
+  :class 'transient-option
+  :shortarg "-B"
+  :argument "--bin="
+  )
+
+(define-infix-argument rustic--transient--doc:-p ()
+  :description "Package to document"
+  :class 'transient-option
+  :shortarg "-p"
+  :argument "--package="
+  )
 
 ;;;###autoload
-(define-transient-command rustic--transient-doc-menu
+(define-transient-command rustic--transient-doc ()
   "Rustic Cargo Doc Commands"
   [["Arguments"
-    ("-q" "Run command without output buffer" ("-q" "--quiet"))
+    (rustic--transient--general:-j)
+    (rustic--transient--doc:-p)
+    (rustic--transient--doc:-b)
+    ("-q" "Run quietly" ("-q" "--quiet"))
     ("-o" "Open doc" ("-o" "--open"))
     ("-a" "Build all docs" ("-a" "--all"))
     ("-d" "Document private items" ("-e" "--document-private-items"))
@@ -62,7 +88,7 @@
     ("-O" "Run without accessing the network" ("-O" "--offline"))
     ]
    ["Make Docs"
-    ("b" "Build docs" test-func-arg)
+    ("b" "Build docs" rustic-cargo-build)
     ("H" "Help" rustic--transient-doc-help)
     ]
    ])
@@ -79,6 +105,28 @@
      ("-V" "Verbose" ("-v" "--verbose"))
      ]]
   )
+
+;;;###autoload
+(define-transient-command rustic--transient-general-menu ()
+  "Rustic Cargo Commands"
+  [
+   ["Quick Commands"
+    (rustic-transient:-trace)
+    ("b" "Build" rustic-cargo-build)
+    ("f" "Format" rustic-cargo-fmt)
+    ("r" "Run" rustic-cargo-run)
+    ("c" "Clippy" rustic-cargo-clippy)
+    ("o" "Outdated" rustic-cargo-outdated)
+    ("e" "Clean" rustic-cargo-clean)
+    ("k" "Check" rustic-cargo-check)
+    ("t" "Test" rustic-cargo-test)
+    ]
+   ["Advanced Cargo Menus"
+    ("D" "Doc" rustic--transient-doc)
+    ("N" "New" rustic--transient-new)
+    ]
+   ])
+
 
 ;;;###autoload
 (defun rustic--transient-doc-help ()
@@ -101,7 +149,8 @@
 (defun rustic--transient-popup ()
   "Invoke the rustic transient popup."
   (interactive)
-  (rustic-mode--transient))
+  (rustic--transient-general-menu))
 
+(rustic--transient-general-menu)
 (provide 'rustic-transient)
 ;;; rustic-transient.el ends here

--- a/rustic-transient.el
+++ b/rustic-transient.el
@@ -4,16 +4,14 @@
 
 (require 'rustic-cargo)
 
-(defvar trace-me nil "Trace level")
-
+;;;###autoload
 (define-infix-command rustic-transient:-trace ()
   :description "Trace level"
   :class 'transient-switch
-  :key "-t"
   :shortarg "-t"
   :argument "--trace-level= "
-  ;; :variable 'trace-me
   :choices '("0" "1" "Full"))
+
 
 (defun rustic-transient--get-args (menu)
   "Retrieve the arguments provided to the transient called MENU."
@@ -24,7 +22,7 @@
   (shell-command (concat "cargo " command " --help") "*Help-Buffer-Rustic*"))
 
 
-;; Load the transient popup only if transient itself is instaled
+;;;###autoload
 (define-transient-command general-menu ()
   "Rustic Cargo Commands"
   [
@@ -39,11 +37,14 @@
     ("k" "Check" rustic-cargo-check)
     ("t" "Test" rustic-cargo-test)
     ]
-   ["Cargo Menus"
+   ["Advanced Cargo Menus"
+    ("D" "Doc" rustic--transient-doc-menu)
+    ("N" "New" rustic--transient-new-menu)
     ]
    ])
 
-(define-transient-command doc-menu
+;;;###autoload
+(define-transient-command rustic--transient-doc-menu
   "Rustic Cargo Doc Commands"
   [["Arguments"
     ("-q" "Run command without output buffer" ("-q" "--quiet"))
@@ -66,13 +67,16 @@
     ]
    ])
 
+;;;###autoload
 (define-transient-command rustic--transient-new ()
   "Transient for cargo new command"
   [[ "Options"
-     ("-q" "Run command without output buffer" ("-q" "--quiet"))
-     ("-V" "Verbose" ("-v" "--verbose"))
+     ("-b" "Use a binary template(DEFAULT)" ("-b" "--bin"))
+     ("-l" "Use a library template" ("-l" "--lib"))
      ("-f" "Require Cargo.lock and cache to be up to date" ("-f" "--frozen"))
      ("-O" "Run without accessing the network" ("-O" "--offline"))
+     ("-q" "Run command without output buffer" ("-q" "--quiet"))
+     ("-V" "Verbose" ("-v" "--verbose"))
      ]]
   )
 
@@ -93,7 +97,6 @@
 (defun rustic--transient-test-help ()
   (rustic--transient-help "test"))
 
-(doc-menu)
 ;; (transient )
 (defun rustic--transient-popup ()
   "Invoke the rustic transient popup."
@@ -102,4 +105,3 @@
 
 (provide 'rustic-transient)
 ;;; rustic-transient.el ends here
-

--- a/rustic-transient.el
+++ b/rustic-transient.el
@@ -10,7 +10,11 @@
   (transient-args menu))
 
 (defun rustic-transient--split-args (menu)
-  (let ((rustic-transient-args '("-abc" "--qeb=afs" "--anothertest=fasfsa fsa FASF"))
+  "Retrieve the arguments passed to MENU and split them.
+Return a single string with both single and double dash arguments(- --) joined
+together."
+  (interactive)
+  (let ((rustic-transient-args (transient-args menu))
         (single-dash '())
         (double-dash '())
         (current-split))
@@ -24,8 +28,8 @@
         (setq single-dash (push arg single-dash))
         )
       )
-    (message "Single %s" single-dash)
-    (message " Double %s" double-dash)
+    (message "Single %s Double %s" single-dash double-dash)
+    (concat (mapconcat 'identity single-dash " ")  " "(mapconcat 'identity double-dash " "))
     )
   )
 
@@ -231,6 +235,11 @@ A new buffer is created which contains the command."
   :argument "--package="
   )
 
+(defun rustic--transient-run-doc ()
+  (interactive)
+  (message "%s" (rustic-transient--split-args 'rustic--transient-doc))
+  )
+
 ;;;###autoload
 (define-transient-command rustic--transient-doc ()
   "Rustic Cargo Doc Commands"
@@ -269,8 +278,8 @@ A new buffer is created which contains the command."
     ]
    ]
   ["Make Docs"
-   ("b" "Build docs" test-args)
-   ("B" "Build docs default" test-args)
+   ("b" "Build docs" rustic--transient-run-doc)
+   ("B" "Build docs default" rustic--transient-run-doc)
    ("H" "Help" rustic--transient-doc-help)
    ]
   )
@@ -294,6 +303,11 @@ A new buffer is created which contains the command."
   :class 'transient-option
   :shortarg "-k"
   :argument "--target="
+  )
+
+(defun rustic--transient-run-clean ()
+  (interactive)
+  (message "%s" (rustic-transient--split-args 'rustic--transient-clean))
   )
 
 ;;;###autoload
@@ -321,6 +335,7 @@ A new buffer is created which contains the command."
    ("-V" "Verbose" ("-v" "--verbose"))
    ]
   ["Commands"
+   ("c" "Run clean with arguments" rustic--transient-run-clean)
    ("H" "Help" rustic--transient-clean-help)
    ]
   )
@@ -353,6 +368,12 @@ A new buffer is created which contains the command."
   :argument "--vcs="
   :choices '("git" "hg" "pijul" "fossil" "none"))
 
+
+(defun rustic--transient-run-new ()
+  (interactive)
+  (message "%s" (rustic-transient--split-args 'rustic--transient-new))
+  )
+
 ;;;###autoload
 (define-transient-command rustic--transient-new ()
   "Transient for cargo new command"
@@ -373,6 +394,8 @@ A new buffer is created which contains the command."
    ("-V" "Verbose" ("-v" "--verbose"))
    ]
   ["Commands"
+   ("n" "Create new project with arguments" rustic--transient-run-new)
+   ("N" "Create new project with defaults" rustic-cargo-new)
    ("H" "Help" rustic--transient-new-help)
    ]
   )

--- a/rustic-transient.el
+++ b/rustic-transient.el
@@ -89,7 +89,6 @@ A new buffer is created which contains the command."
   (interactive)
   (rustic--transient-help "uninstall"))
 
-;;;###autoload
 (defun test-args (&optional args)
   (interactive)
   (message "%s" (rustic-transient--get-args 'rustic--transient-doc)))
@@ -131,18 +130,40 @@ A new buffer is created which contains the command."
   :argument "--target-dir="
   )
 
-(define-infix-argument rustic--transient--clean:-D ()
-  :description "Directory for all generated artifacts"
-  :class 'transient-option
-  :shortarg "-D"
-  :argument "--target-dir="
-  )
-
 (define-infix-argument rustic--transient--general:-m ()
   :description "Path to Cargo.toml"
   :class 'transient-option
   :shortarg "-m"
   :argument "--manifest-path="
+  )
+
+;;;###autoload
+(define-transient-command rustic--transient-general-menu ()
+  "Rustic Cargo Commands"
+  [
+   ["Quick Commands"
+    (rustic-transient:--trace)
+    ("b" "Build" rustic-cargo-build)
+    ("f" "Format" rustic-cargo-fmt)
+    ("r" "Run" rustic-cargo-run)
+    ("c" "Clippy" rustic-cargo-clippy)
+    ("o" "Outdated" rustic-cargo-outdated)
+    ("e" "Clean" rustic-cargo-clean)
+    ("k" "Check" rustic-cargo-check)
+    ("t" "Test" rustic-cargo-test)
+    ]
+   ["Advanced Cargo Menus"
+    ("D" "Doc" rustic--transient-doc)
+    ("N" "New" rustic--transient-new)
+    ("T" "Test" rustic--transient-test)
+    ]
+   ])
+
+(define-infix-argument rustic--transient--doc:-F ()
+  :description "Space separated list of features to activate"
+  :class 'transient-option
+  :shortarg "-F"
+  :argument "--features="
   )
 
 (define-infix-argument rustic--transient--doc:-b ()
@@ -158,56 +179,6 @@ A new buffer is created which contains the command."
   :shortarg "-p"
   :argument "--package="
   )
-
-(define-infix-argument rustic--transient--clean:-p ()
-  :description "Package to clean artifacts for"
-  :class 'transient-option
-  :shortarg "-p"
-  :argument "--package="
-  )
-
-(define-infix-argument rustic--transient--clean:-p ()
-  :description "Package to clean artifacts for"
-  :class 'transient-option
-  :shortarg "-p"
-  :argument "--package="
-  )
-
-(define-infix-argument rustic--transient--doc:-F ()
-  :description "Space separated list of features to activate"
-  :class 'transient-option
-  :shortarg "-F"
-  :argument "--features="
-  )
-
-
-(define-infix-argument rustic--transient--new:-r ()
-  :description "Package to document"
-  :class 'transient-option
-  :shortarg "-r"
-  :argument "--registry= "
-  )
-
-(define-infix-argument rustic--transient--new:-e ()
-  :description "Edition of the package"
-  :class 'transient-switch
-  :shortarg "-e"
-  :argument "--edition= "
-  )
-
-(define-infix-argument rustic--transient--new:-n ()
-  :description "Name of the new package"
-  :class 'transient-switch
-  :shortarg "-n"
-  :argument "--name= "
-  )
-
-(define-infix-command rustic--transient--new:-v ()
-  :description "Version control system to be used"
-  :class 'transient-switch
-  :shortarg "-v"
-  :argument "--vcs="
-  :choices '("git" "hg" "pijul" "fossil" "none"))
 
 ;;;###autoload
 (define-transient-command rustic--transient-doc ()
@@ -241,6 +212,20 @@ A new buffer is created which contains the command."
     ]
    ])
 
+(define-infix-argument rustic--transient--clean:-D ()
+  :description "Directory for all generated artifacts"
+  :class 'transient-option
+  :shortarg "-D"
+  :argument "--target-dir="
+  )
+
+(define-infix-argument rustic--transient--clean:-p ()
+  :description "Package to clean artifacts for"
+  :class 'transient-option
+  :shortarg "-p"
+  :argument "--package="
+  )
+
 ;;;###autoload
 (define-transient-command rustic--transient-clean ()
   "Rustic Cargo Clean Menu"
@@ -252,6 +237,74 @@ A new buffer is created which contains the command."
     (rustic--transient--clean:-D)
     ("-r" "Clean release artifacts" ("-r" "--release"))
     ("-d" "Clean just the documentation directory" ("-d" "--doc"))
+    ("-V" "Verbose" ("-v" "--verbose"))
+    ("-f" "Require Cargo.lock and cache to be up to date" ("-f" "--frozen"))
+    ("-P" "Require Cargo.lock to be up to date" ("-P" "--locked"))
+    ("-O" "Run without accessing the network" ("-O" "--offline"))
+    ]
+   ]
+  )
+
+(define-infix-argument rustic--transient--new:-r ()
+  :description "Package to document"
+  :class 'transient-option
+  :shortarg "-r"
+  :argument "--registry= "
+  )
+
+(define-infix-argument rustic--transient--new:-e ()
+  :description "Edition of the package"
+  :class 'transient-switch
+  :shortarg "-e"
+  :argument "--edition= "
+  )
+
+(define-infix-argument rustic--transient--new:-n ()
+  :description "Name of the new package"
+  :class 'transient-switch
+  :shortarg "-n"
+  :argument "--name= "
+  )
+
+(define-infix-command rustic--transient--new:-v ()
+  :description "Version control system to be used"
+  :class 'transient-switch
+  :shortarg "-v"
+  :argument "--vcs="
+  :choices '("git" "hg" "pijul" "fossil" "none"))
+
+;;;###autoload
+(define-transient-command rustic--transient-new ()
+  "Transient for cargo new command"
+  [[ "Options"
+     (rustic--transient--new:-e)
+     (rustic--transient--new:-n)
+     (rustic--transient--new:-r)
+     (rustic--transient--new:-v)
+     ("-b" "Use a binary template(DEFAULT)" ("-b" "--bin"))
+     ("-l" "Use a library template" ("-l" "--lib"))
+     ("-f" "Require Cargo.lock and cache to be up to date" ("-f" "--frozen"))
+     ("-O" "Run without accessing the network" ("-O" "--offline"))
+     ("-q" "Run command without output buffer" ("-q" "--quiet"))
+     ("-V" "Verbose" ("-v" "--verbose"))
+     ]
+   ["Commands"
+    ("H" "Help" rustic--transient-new-help)
+    ]
+   ]
+  )
+
+;;;###autoload
+(define-transient-command rustic--transient-run ()
+  "Rustic Cargo Run Menu"
+  ["Arguments"
+   [
+    ("-q" "Run quietly" ("-q" "--quiet"))
+    ("-r" "Clean release artifacts" ("-r" "--release"))
+    (rustic--transient--general:-m)
+    (rustic--transient--general:-j)
+    ("-A" "All features" ("-A" "--all-features"))
+    ("-n" "No default features" ("-n" "--no-default-features"))
     ("-V" "Verbose" ("-v" "--verbose"))
     ("-f" "Require Cargo.lock and cache to be up to date" ("-f" "--frozen"))
     ("-P" "Require Cargo.lock to be up to date" ("-P" "--locked"))
@@ -276,50 +329,7 @@ A new buffer is created which contains the command."
     ]
    ])
 
-;;;###autoload
-(define-transient-command rustic--transient-new ()
-  "Transient for cargo new command"
-  [[ "Options"
-     (rustic--transient--new:-e)
-     (rustic--transient--new:-n)
-     (rustic--transient--new:-r)
-     (rustic--transient--new:-v)
-     ("-b" "Use a binary template(DEFAULT)" ("-b" "--bin"))
-     ("-l" "Use a library template" ("-l" "--lib"))
-     ("-f" "Require Cargo.lock and cache to be up to date" ("-f" "--frozen"))
-     ("-O" "Run without accessing the network" ("-O" "--offline"))
-     ("-q" "Run command without output buffer" ("-q" "--quiet"))
-     ("-V" "Verbose" ("-v" "--verbose"))
-     ]
-   ["Commands"
-    ("H" "Help" rustic--transient-new-help)
-    ]
-   ]
-  )
-
-;;;###autoload
-(define-transient-command rustic--transient-general-menu ()
-  "Rustic Cargo Commands"
-  [
-   ["Quick Commands"
-    (rustic-transient:--trace)
-    ("b" "Build" rustic-cargo-build)
-    ("f" "Format" rustic-cargo-fmt)
-    ("r" "Run" rustic-cargo-run)
-    ("c" "Clippy" rustic-cargo-clippy)
-    ("o" "Outdated" rustic-cargo-outdated)
-    ("e" "Clean" rustic-cargo-clean)
-    ("k" "Check" rustic-cargo-check)
-    ("t" "Test" rustic-cargo-test)
-    ]
-   ["Advanced Cargo Menus"
-    ("D" "Doc" rustic--transient-doc)
-    ("N" "New" rustic--transient-new)
-    ("T" "Test" rustic--transient-test)
-    ]
-   ])
-
-(defun rustic--transient-popup ()
+(defun rustic-transient-popup ()
   "Invoke the rustic transient popup."
   (interactive)
   (rustic--transient-general-menu))

--- a/rustic-transient.el
+++ b/rustic-transient.el
@@ -193,6 +193,7 @@ A new buffer is created which contains the command."
    ["Advanced Cargo Menus"
     ("D" "Doc" rustic--transient-doc)
     ("N" "New" rustic--transient-new)
+    ("C" "Clean" rustic--transient-clean)
     ("T" "Test" rustic--transient-test)
     ]
    ])
@@ -287,19 +288,25 @@ A new buffer is created which contains the command."
 (define-transient-command rustic--transient-clean ()
   "Rustic Cargo Clean Menu"
   [
-   ["Arguments"
-    ("-q" "Run quietly" ("-q" "--quiet"))
+   ["Package and Clean Options"
     (rustic--transient--clean:-p)
-    (rustic--transient--general:-m)
     (rustic--transient--clean:-D)
     (rustic--transient--clean:-k)
     ("-r" "Clean release artifacts" ("-r" "--release"))
     ("-d" "Clean just the documentation directory" ("-d" "--doc"))
-    ("-V" "Verbose" ("-v" "--verbose"))
+    ]
+   ]
+  [
+   ["Manifest"
+    (rustic--transient--general:-m)
     ("-f" "Require Cargo.lock and cache to be up to date" ("-f" "--frozen"))
     ("-P" "Require Cargo.lock to be up to date" ("-P" "--locked"))
     ("-O" "Run without accessing the network" ("-O" "--offline"))
     ]
+   ]
+  ["Display"
+   ("-q" "Run quietly" ("-q" "--quiet"))
+   ("-V" "Verbose" ("-v" "--verbose"))
    ]
   ["Commands"
    ("H" "Help" rustic--transient-clean-help)

--- a/rustic-transient.el
+++ b/rustic-transient.el
@@ -125,21 +125,28 @@ A new buffer is created which contains the command."
   )
 
 (define-infix-argument rustic--transient--general:-D ()
-  :description "Packages to exclude"
+  :description "Directory for all generated artifacts"
+  :class 'transient-option
+  :shortarg "-D"
+  :argument "--target-dir="
+  )
+
+(define-infix-argument rustic--transient--clean:-D ()
+  :description "Directory for all generated artifacts"
   :class 'transient-option
   :shortarg "-D"
   :argument "--target-dir="
   )
 
 (define-infix-argument rustic--transient--general:-m ()
-  :description "Packages to exclude"
+  :description "Path to Cargo.toml"
   :class 'transient-option
   :shortarg "-m"
   :argument "--manifest-path="
   )
 
 (define-infix-argument rustic--transient--doc:-b ()
-  :description "Packages to exclude"
+  :description "Document only the specified binary"
   :class 'transient-option
   :shortarg "-B"
   :argument "--bin="
@@ -151,6 +158,28 @@ A new buffer is created which contains the command."
   :shortarg "-p"
   :argument "--package="
   )
+
+(define-infix-argument rustic--transient--clean:-p ()
+  :description "Package to clean artifacts for"
+  :class 'transient-option
+  :shortarg "-p"
+  :argument "--package="
+  )
+
+(define-infix-argument rustic--transient--clean:-p ()
+  :description "Package to clean artifacts for"
+  :class 'transient-option
+  :shortarg "-p"
+  :argument "--package="
+  )
+
+(define-infix-argument rustic--transient--doc:-F ()
+  :description "Space separated list of features to activate"
+  :class 'transient-option
+  :shortarg "-F"
+  :argument "--features="
+  )
+
 
 (define-infix-argument rustic--transient--new:-r ()
   :description "Package to document"
@@ -184,12 +213,17 @@ A new buffer is created which contains the command."
 (define-transient-command rustic--transient-doc ()
   "Rustic Cargo Doc Commands"
   [["Arguments"
-    (rustic--transient--general:-j)
-    (rustic--transient--doc:-p)
     (rustic--transient--doc:-b)
+    (rustic--transient--doc:-p)
+    (rustic--transient--doc:-F)
+    (rustic--transient--general:-m)
+    (rustic--transient--general:-D)
+    (rustic--transient--general:-e)
+    (rustic--transient--general:-j)
     ("-q" "Run quietly" ("-q" "--quiet"))
     ("-o" "Open doc" ("-o" "--open"))
     ("-a" "Build all docs" ("-a" "--all"))
+    ("-N" "No dependiencies" ("-N" "--no-deps"))
     ("-d" "Document private items" ("-e" "--document-private-items"))
     ("-l" "Document Only this package's library" ("-l"
                                                   "--document-private-items"))
@@ -206,6 +240,25 @@ A new buffer is created which contains the command."
     ("H" "Help" rustic--transient-doc-help)
     ]
    ])
+
+;;;###autoload
+(define-transient-command rustic--transient-clean ()
+  "Rustic Cargo Clean Menu"
+  [
+   ["Arguments"
+    ("-q" "Run quietly" ("-q" "--quiet"))
+    (rustic--transient--clean:-p)
+    (rustic--transient--general:-m)
+    (rustic--transient--clean:-D)
+    ("-r" "Clean release artifacts" ("-r" "--release"))
+    ("-d" "Clean just the documentation directory" ("-d" "--doc"))
+    ("-V" "Verbose" ("-v" "--verbose"))
+    ("-f" "Require Cargo.lock and cache to be up to date" ("-f" "--frozen"))
+    ("-P" "Require Cargo.lock to be up to date" ("-P" "--locked"))
+    ("-O" "Run without accessing the network" ("-O" "--offline"))
+    ]
+   ]
+  )
 
 ;;;###autoload
 (define-transient-command rustic--transient-test ()


### PR DESCRIPTION
As mentioned in #55, I have started working on a transient for cargo. It is not finished yet but if you would like to, you can take a look at it/try to run it. All suggestions about layout/documentation/functions are welcome.

As of right now, it does not invoke any commands. I have simply created a function which splits the arguments and prints them in the minibuffer. The most complete transient is the `doc` one which only needs to have calls added for cargo to run the command.

You can run the main transient with the command `rustic-transient-popup` after you evaluate the `rustic-transient.el` file.

I have split the menu into two parts. There are the quick shortcuts(current rustic-popup commands) and there is the full menu(right side) which gives complete control to the flags passed by cargo.

Here are some images:

![transientMain](https://user-images.githubusercontent.com/7553015/62013671-77f8c880-b14a-11e9-8af9-6c1191b9c67b.png)

![transientDoc](https://user-images.githubusercontent.com/7553015/62013672-7b8c4f80-b14a-11e9-9c63-125e49b9c244.png)
