### PR TITLE
use right keymap name in rustic-mode docstring

### DIFF
--- a/rustic.el
+++ b/rustic.el
@@ -176,7 +176,7 @@ to the function arguments.  When nil, `->' will be indented one level."
 (define-derived-mode rustic-mode prog-mode "Rust"
   "Major mode for Rust code.
 
-\\{rustic-map}"
+\\{rustic-mode-map}"
   :group 'rustic
   :syntax-table rustic-syntax-table
 


### PR DESCRIPTION
rustic defines a rustic-mode-map keymap, not rustic-map. this fix will
properly show the available bindings when running M-x
describe-mode (C-h m) while in rust source buffer.