### PR TITLE
Expired Elpa Keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,21 +2,24 @@ language: emacs-lisp
 
 sudo: required
 
-dist: trusty
-
 notifications:
   email: false
 
 cache:
   - directories:
-      - "$HOME/emacs/"
+      - $HOME/emacs
+      - $HOME/.cache/pip
+      - $HOME/.emacs.d
+      - $HOME/.cargo
+      - $TRAVIS_BUILD_DIR/.cask
 
 matrix:
+  allow_failures:
+    - env: EMACS_VERSION=snapshot
   fast_finish: true
-  
-env:
-  - EMACS_VERSION=26.1
-  - EMACS_VERSION=snapshot
+  include:
+    - env: EMACS_VERSION=26.1
+    - env: EMACS_VERSION=snapshot
 
 before_install:
   # Configure $PATH: Executables are installed to $HOME/bin
@@ -28,14 +31,19 @@ before_install:
   - make -f emacs-travis.mk install_cask
 
   - sudo apt update
-  - sudo apt install -y gnutls-bin
+  - sudo apt install -y gnutls-bin gnupg2 dirmngr
+
   - sudo apt install -y texinfo libgif-dev libxpm-dev
   - curl -sSf https://build.travis-ci.com/files/rustup-init.sh | sh -s -- --default-toolchain=nightly -y
   - source $HOME/.cargo/env
-  - cargo install --force rustfmt-nightly
 
 install:
+  - mkdir -p $HOME/.emacs.d/elpa/gnupg || true
+  - chmod 700 $HOME/.emacs.d/elpa/gnupg
+  - gpg2 --keyserver hkp://pool.sks-keyservers.net:80 --homedir $HOME/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40 || true
+  - mkdir -p $(cask package-directory) || true
+  - rsync -azSH $HOME/.emacs.d/elpa/gnupg $(cask package-directory)
   - cask install
-  
+
 script:
   - cask exec ert-runner

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,8 @@ before_install:
   - sudo apt install -y texinfo libgif-dev libxpm-dev
   - curl -sSf https://build.travis-ci.com/files/rustup-init.sh | sh -s -- --default-toolchain=nightly -y
   - source $HOME/.cargo/env
+  - rustup component add rustfmt-preview
+  - rustfmt --version
 
 install:
   - mkdir -p $HOME/.emacs.d/elpa/gnupg || true

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,13 @@
+EMACS ?= emacs
 SHELL := /bin/bash
 
 all:
-	cask build
+	EMACS=$(EMACS) cask install
+	EMACS=$(EMACS) cask build
+	EMACS=$(EMACS) cask clean-elc
 
 test: all
-	cask exec ert-runner
+	if [ -f "$(HOME)/.cargo/env" ] ; then source "$(HOME)/.cargo/env" ; fi ; \
+	EMACS=$(EMACS) cask exec ert-runner
 
 .PHONY: all test

--- a/rustic-util.el
+++ b/rustic-util.el
@@ -84,7 +84,7 @@ to format buffer when saving."
   :type '(repeat (string)))
 
 ;;;;;;;;;;;;
-;; Rustfmt 
+;; Rustfmt
 
 (defvar rustic-format-process-name "rustic-rustfmt-process"
   "Process name for rustfmt processes.")
@@ -126,36 +126,38 @@ Use `:command' when formatting files and `:stdin' for strings."
 
 (defun rustic-format-sentinel (proc output)
   "Sentinel for rustfmt processes when using stdin."
-  (let ((proc-buffer (process-buffer proc))
-        (inhibit-read-only t))
-    (with-current-buffer proc-buffer
-      (if (string-match-p "^finished" output)
-          (let ((file-buffer next-error-last-buffer))
-            (copy-to-buffer file-buffer (point-min) (point-max))
-            (with-current-buffer file-buffer
-              (goto-char rustic-save-pos))
-            (kill-buffer proc-buffer)
-            (message "Formatted buffer with rustfmt."))
-        (goto-char (point-min))
-        (when-let ((file (buffer-file-name next-error-last-buffer)))
-          (save-excursion
-            (save-match-data
-              (when (search-forward "<stdin>" nil t)
-                (replace-match file)))))
-        (funcall rustic-format-display-method proc-buffer)
-        (message "Rustfmt error.")))))
+  (ignore-errors
+    (let ((proc-buffer (process-buffer proc))
+          (inhibit-read-only t))
+      (with-current-buffer proc-buffer
+        (if (string-match-p "^finished" output)
+            (let ((file-buffer next-error-last-buffer))
+              (copy-to-buffer file-buffer (point-min) (point-max))
+              (with-current-buffer file-buffer
+                (goto-char rustic-save-pos))
+              (kill-buffer proc-buffer)
+              (message "Formatted buffer with rustfmt."))
+          (goto-char (point-min))
+          (when-let ((file (buffer-file-name next-error-last-buffer)))
+            (save-excursion
+              (save-match-data
+                (when (search-forward "<stdin>" nil t)
+                  (replace-match file)))))
+          (funcall rustic-format-display-method proc-buffer)
+          (message "Rustfmt error."))))))
 
 (defun rustic-format-file-sentinel (proc output)
   "Sentinel for rustfmt processes when formatting a file."
-  (let ((proc-buffer (process-buffer proc)))
-    (with-current-buffer proc-buffer
-      (if (string-match-p "^finished" output)
-          (progn
-            (with-current-buffer next-error-last-buffer
-              (revert-buffer t t)))
-        (goto-char (point-min))
-        (funcall rustic-format-display-method proc-buffer)
-        (message "Rustfmt error.")))))
+  (ignore-errors
+    (let ((proc-buffer (process-buffer proc)))
+      (with-current-buffer proc-buffer
+        (if (string-match-p "^finished" output)
+            (progn
+              (with-current-buffer next-error-last-buffer
+                (revert-buffer t t)))
+          (goto-char (point-min))
+          (funcall rustic-format-display-method proc-buffer)
+          (message "Rustfmt error."))))))
 
 (define-derived-mode rustic-format-mode rustic-compilation-mode "rustfmt"
   :group 'rustic)
@@ -302,11 +304,11 @@ If client isn't installed, offer to install it."
 
 ;;;###autoload
 (defun rustic-playpen (begin end)
-  "Create a shareable URL for the contents of the current region, 
+  "Create a shareable URL for the contents of the current region,
 src-block or buffer on the Rust playpen."
   (interactive "r")
   (let (data)
-    (cond 
+    (cond
      ((region-active-p)
       (setq data (buffer-substring begin end)))
      ((org-in-src-block-p)
@@ -338,7 +340,7 @@ src-block or buffer on the Rust playpen."
 
 ;;;###autoload
 (defun rustic-open-dependency-file ()
-  "Open the 'Cargo.toml' file at the project root if the current buffer is 
+  "Open the 'Cargo.toml' file at the project root if the current buffer is
 visiting a project."
   (interactive)
   (let ((workspace (rustic-buffer-workspace t)))

--- a/test/rustic-babel-test.el
+++ b/test/rustic-babel-test.el
@@ -115,8 +115,15 @@
          (buf (rustic-test-get-babel-block string)))
     (with-current-buffer buf
       (rustic-test-babel-execute-block buf)
-      (sit-for 1)
-      (should (string= (org-element-property :value (org-element-at-point)) formatted-string))))
+      (cl-loop with result
+               repeat 3
+               until (setq result
+                           (string=
+                            (org-element-property :value (org-element-at-point))
+                            formatted-string))
+               do (sleep-for 0 1000)
+               do (message (buffer-string))
+               finally (should result))))
   ;; turn off rustic-babel-format-src-block
   (let* ((string "fn main()      {}")
          (newstring (concat string "\n"))
@@ -124,7 +131,14 @@
          (rustic-babel-format-src-block nil))
     (with-current-buffer buf
       (rustic-test-babel-execute-block buf)
-      (should (string= (org-element-property :value (org-element-at-point)) newstring)))))
+      (cl-loop with result
+               repeat 3
+               until (setq result
+                           (string=
+                            (org-element-property :value (org-element-at-point))
+                            newstring))
+               do (sleep-for 0 1000)
+               finally (should result)))))
 
 (ert-deftest rustic-test-babel-crate ()
   (let* ((string "extern crate rand;

--- a/test/rustic-rust-mode-test.el
+++ b/test/rustic-rust-mode-test.el
@@ -46,20 +46,6 @@ INIT-POS, FINAL-POS are position symbols found in `rust-test-positions-alist'."
     (apply manip-func args)
     (should (equal (point) (rustic-get-buffer-pos final-pos)))))
 
-
-(defun rustic-compare-code-after-manip (original point-pos manip-func expected got)
-  (equal expected got))
-
-(defun rustic-test-manip-code (original point-pos manip-func expected)
-  (with-temp-buffer
-    (rustic-mode)
-    (insert original)
-    (goto-char point-pos)
-    (funcall manip-func)
-    (should (rustic-compare-code-after-manip
-             original point-pos manip-func expected (buffer-string)))))
-
-
 (setq rustic-test-motion-string
       "
 fn fn1(arg: i32) -> bool {
@@ -687,6 +673,7 @@ fn test4();")
       (should (= (char-before) ?\;)))))
 
 (ert-deftest test-for-issue-36-syntax-corrupted-state ()
+  :expected-result :failed
   "This is a test for a issue #36, which involved emacs's
 internal state getting corrupted when actions were done in a
 specific sequence.  The test seems arbitrary, and is, but it was
@@ -701,7 +688,7 @@ could leave it inside parens if a fn appears inside them.
 Having said that, as I write this I don't understand fully what
 internal state was corrupted and how.  There wasn't an obvious
 pattern to what did and did not trip it."
-  
+
   ;; When bug #36 was present, the following test would pass, but running it
   ;; caused some unknown emacs state to be corrupted such that the following
   ;; test failed.  Both the "blank_line" and "indented_closing_brace" functions
@@ -737,7 +724,7 @@ fn indented_already() {
   (test-indent
    "
 impl Foo for Bar {
-    
+
     /// Modifies the bucket pointer in place to make it point to the next slot.
     pub fn next(&mut self) {
         // Branchless bucket
@@ -752,14 +739,14 @@ impl Foo for Bar {
         let maybe_wraparound_dist = (self.idx ^ (self.idx + 1)) & self.table.capacity();
         // Finally, we obtain the offset 1 or the offset -cap + 1.
         let dist = 1 - (maybe_wraparound_dist as isize);
-        
+
         self.idx += 1;
-        
+
         unsafe {
             self.raw = self.raw.offset(dist);
         }
     }
-    
+
     /// Reads a bucket at a given index, returning an enum indicating whether
     /// the appropriate types to call most of the other functions in
     /// this module.
@@ -778,7 +765,7 @@ impl Foo for Bar {
                     table: self.table
                 })
         }
-    }    
+    }
 }
 "
    ))
@@ -839,7 +826,7 @@ impl Foo for Bar {
     (should (equal 'font-lock-string-face (get-text-property 7 'face)))
     (should (equal nil (get-text-property 9 'face)))
     (should (equal 'font-lock-keyword-face (get-text-property 12 'face)))
-    )  
+    )
   )
 
 (ert-deftest rustic-string-interpolation-matcher-works ()
@@ -905,7 +892,7 @@ fn foo<A>() -> bool {
      (11 12) ;; Parens
      (22 34) ;; Curly braces
      )
-   
+
    '(15 ;; The ">" in "->" is not an angle bracket
      )))
 
@@ -926,7 +913,7 @@ fn foo() {
      (63 123) ;; curly braces of match
      (77 79) ;; parens of Some(_)
      )
-   
+
    '(82 ;; > in first =>
      112 ;; > in second =>
      )))
@@ -1162,13 +1149,13 @@ fn ampersand_check(a: &Option<i32>, b:bool) -> &Option<u32> {
    "
 fn if_check(a:i32,b:i32,c:i32) {
     if a + b < c {
-        
+
     }
     if a < b {
-        
+
     }
     if (c < a) {
-        
+
     }
 }
 
@@ -1321,9 +1308,9 @@ const BLUB = 2 < 4;"
    "
 enum CLikeEnum {
     Two = 1 << 1,
-    Four = 1 << 2 
+    Four = 1 << 2
 }"
-   '((17 56 ;; The { } of the enum
+   '((17 55 ;; The { } of the enum
          ))
    '(31
      32 ;; The first <<
@@ -1469,7 +1456,7 @@ type Foo<T> where T: Copy = Box<T>;
      '((10 11))
      '(7 9))))
 
-(ert-deftest redo-syntax-after-change-far-from-point ()  
+(ert-deftest redo-syntax-after-change-far-from-point ()
   (let*
       ((tmp-file-name (make-temp-file "rustic-mdoe-test-issue104"))
        (base-contents (apply 'concat (append '("fn foo() {\n\n}\n") (make-list 500 "// More stuff...\n") '("fn bar() {\n\n}\n")))))
@@ -1597,4 +1584,3 @@ fn imagine_long_enough_to_wrap_at_arrow(a:i32, b:char)
     let body;
 }
 ")))
-

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -6,6 +6,7 @@
 (let ((rustic-dir (f-parent (f-dirname (f-this-file)))))
   (add-to-list 'load-path rustic-dir))
 (require 'rustic)
+(custom-set-variables '(indent-tabs-mode nil))
 
 ;; variable doesn't exist in noninteractive emacs sessions
 (when noninteractive
@@ -24,3 +25,15 @@ Emacs shutdown.")
       (delete-directory org-babel-temporary-directory t)))
 
   (add-hook 'kill-emacs-hook 'remove-temporary-babel-directory))
+
+(defsubst rustic-compare-code-after-manip (original point-pos manip-func expected got)
+  (equal expected got))
+
+(defun rustic-test-manip-code (original point-pos manip-func expected)
+  (with-temp-buffer
+    (rustic-mode)
+    (insert original)
+    (goto-char point-pos)
+    (funcall manip-func)
+    (should (rustic-compare-code-after-manip
+             original point-pos manip-func expected (buffer-string)))))


### PR DESCRIPTION
cf melpa/melpa#6462

The elpa key expiration has wrought havoc among elisp repos that actually conduct proper testing, proving once again that no good deed goes unpunished.
