### PR TITLE
make rustic-compile match its docstring

### DIFF
--- a/rustic-compile.el
+++ b/rustic-compile.el
@@ -439,7 +439,7 @@ Otherwise use provided argument ARG and store it in
 `compilation-arguments'."
   (interactive "P")
   (let* ((command (setq compilation-arguments
-                        (if arg
+                        (if (not arg)
                             (read-from-minibuffer "Compile command: ")
                           rustic-compile-command)))
          (dir (setq compilation-directory (rustic-buffer-workspace))))


### PR DESCRIPTION
The docstring claims that rustic-compile, if invoked without
arguments, will prompt for the command. But in fact it did not do so.