### PR TITLE
Refactor package.el dependency out of lsp client setup

### DIFF
--- a/rustic-util.el
+++ b/rustic-util.el
@@ -232,15 +232,10 @@ were issues when using stdin for formatting."
 (defun rustic-setup-lsp ()
   "Setup LSP client. If client isn't installed, offer to install it."
   (unless noninteractive ;; TODO: fix tests to work with eglot/lsp-mode activated
-    (let ((client-p (lambda (c)
-                      (or (featurep 'straight)
-                          (if (package-installed-p c)
-                              (or (featurep c) (require c))
-                            nil))))
-          (client (or rustic-rls-pkg rustic-lsp-client)))
+    (let ((client (or rustic-rls-pkg rustic-lsp-client)))
       (cond ((eq client nil)
              nil)
-            ((not (eq (funcall client-p client) nil))
+            ((require client nil t))
              (if (eq client 'eglot)
                  (eglot-ensure)
                (lsp-workspace-folders-add (rustic-buffer-workspace))


### PR DESCRIPTION
This is a simpler way to determine if lsp-mode or eglot is available, without depending on package.el.

`(require X nil t)` returns nil if it fails to load `X`, but will return non-nil if it succeeds.