### PR TITLE
Manually load lsp-rust

### DIFF
--- a/rustic-util.el
+++ b/rustic-util.el
@@ -247,6 +247,7 @@ were issues when using stdin for formatting."
 with `lsp-rust-switch-server'."
   ;; we need to require lsp-clients for the call to `lsp--client-priority'
   (require 'lsp-clients)
+  (require 'lsp-rust)
   (lsp-workspace-folders-add (rustic-buffer-workspace))
   (setq lsp-rust-server rustic-lsp-server)
   (setq lsp-rust-analyzer-server-command rustic-analyzer-command)


### PR DESCRIPTION
This acts as a workaround for #85.
It appears lsp-mode has changed the way that loading lsp-clients works, and simply requiring
lsp-clients does not appear to be enough anymore, so we additionally directly require lsp-rust.