### PR TITLE
upstream: Check for -> and => early in rust-ordinary-lt-gt-p

### DIFF
--- a/rustic.el
+++ b/rustic.el
@@ -939,6 +939,11 @@ should be considered a paired angle bracket."
    ;; If matching is turned off suppress all of them
    ((not rustic-match-angle-brackets) t)
 
+   ;; This is a cheap check so we do it early.
+   ;; Don't treat the > in -> or => as an angle bracket
+   ((and (= (following-char) ?>) (memq (preceding-char) '(?- ?=))) t)
+
+
    ;; We don't take < or > in strings or comments to be angle brackets
    ((rustic-in-str-or-cmnt) t)
 


### PR DESCRIPTION
Thanks to tspiteri

As discussed here https://github.com/brotzeit/rustic/issues/107, this should also speed up syntax-propertize for files with lots of `->` or `=>` symbols in it.