### PR TITLE
Recognize async functions when running individual tests

### DIFF
--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -114,7 +114,7 @@ When calling this function from `rustic-popup-mode', always use the value of
 (defconst rustic-cargo-mod-regexp
   "^\s*mod\s+\\([[:word:][:multibyte:]_][[:word:][:multibyte:]_[:digit:]]*\\)\s*{")
 (defconst rustic-cargo-fn-regexp
-  "^\s*fn\s+\\([^(]+\\)\s*(")
+  "^\s*\\(?:async\\)?\s+fn\s+\\([^(]+\\)\s*(")
 
 (defun rustic-cargo--get-current-fn-fullname()
   "Return full name of the fn around point including module name if any."

--- a/rustic-interaction.el
+++ b/rustic-interaction.el
@@ -344,7 +344,7 @@ visit the new file."
 ;;; Defun Motions
 
 (defvar rustic-func-item-beg-re
-  (concat "\\s-*\\(?:priv\\|pub\\)?\\s-*"
+  (concat "\\s-*\\(?:priv\\|pub\\)?\\s-*\\(?:async\\)?\\s-*"
           (regexp-opt '("fn")))
   "Start of a rust function.")
 


### PR DESCRIPTION
Tweak regex strings a bit. Without this change, no tests are run with `rustic-cargo-current-test`