### PR TITLE
Add rustic-rustfmt-config-alist.

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Rust edition 2018 requires a `rustfmt.toml` file.
 Customization:
 
 - `rustic-rustfmt-bin` path to rustfmt executable
-- `rustic-rustfmt-args` extra arguments to rustfmt
+- `rustic-rustfmt-config-alist` alist of rustfmt configuration options
 - `rustic-format-display-method` default function used for displaying
   rustfmt buffer (use the function `ignore`, if you don't want the
   buffer to be displayed)

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Rust edition 2018 requires a `rustfmt.toml` file.
 Customization:
 
 - `rustic-rustfmt-bin` path to rustfmt executable
+- `rustic-rustfmt-args` extra arguments to rustfmt
 - `rustic-format-display-method` default function used for displaying
   rustfmt buffer (use the function `ignore`, if you don't want the
   buffer to be displayed)

--- a/rustic-babel.el
+++ b/rustic-babel.el
@@ -80,7 +80,7 @@ execution with rustfmt."
                   (proc
                    (make-process :name "rustic-babel-format"
                                  :buffer "rustic-babel-format-buffer"
-                                 :command `(,rustic-rustfmt-bin)
+                                 :command `(,rustic-rustfmt-bin ,@rustic-rustfmt-args)
                                  :filter #'rustic-compilation-filter
                                  :sentinel #'rustic-babel-format-sentinel)))
               (while (not (process-live-p proc))

--- a/rustic-babel.el
+++ b/rustic-babel.el
@@ -80,7 +80,8 @@ execution with rustfmt."
                   (proc
                    (make-process :name "rustic-babel-format"
                                  :buffer "rustic-babel-format-buffer"
-                                 :command `(,rustic-rustfmt-bin ,@rustic-rustfmt-args)
+                                 :command `(,rustic-rustfmt-bin
+                                            ,@(rustic-compute-rustfmt-args))
                                  :filter #'rustic-compilation-filter
                                  :sentinel #'rustic-babel-format-sentinel)))
               (while (not (process-live-p proc))

--- a/rustic-common.el
+++ b/rustic-common.el
@@ -71,6 +71,14 @@ not in a rust project."
       (if nodefault
           nil default-directory))))
 
+(defun rustic-compute-rustfmt-args ()
+  "Compute the arguments to rustfmt from `rustic-rustfmt-config-alist'."
+  (let (args)
+    (cl-dolist (elem rustic-rustfmt-config-alist args)
+      (cl-destructuring-bind (key . val) elem
+        (push (format "%s=%s" key (if (booleanp val) (if val "true" "false") val)) args)
+        (push "--config" args)))))
+
 ;;; Spinner
 
 (require 'spinner)

--- a/rustic-common.el
+++ b/rustic-common.el
@@ -18,6 +18,11 @@
   :type 'string
   :group 'rustic)
 
+(defcustom rustic-rustfmt-args nil
+  "List of arguments to rustfmt."
+  :type '(repeat string)
+  :group 'rustic)
+
 (defcustom rustic-lsp-setup-p t
   "Setup LSP related stuff automatically."
   :type 'boolean

--- a/rustic-common.el
+++ b/rustic-common.el
@@ -18,11 +18,6 @@
   :type 'string
   :group 'rustic)
 
-(defcustom rustic-rustfmt-args nil
-  "List of arguments to rustfmt."
-  :type '(repeat string)
-  :group 'rustic)
-
 (defcustom rustic-rustfmt-config-alist nil
   "An alist of (KEY . VAL) pairs that are passed to rustfmt.
 

--- a/rustic-common.el
+++ b/rustic-common.el
@@ -23,6 +23,15 @@
   :type '(repeat string)
   :group 'rustic)
 
+(defcustom rustic-rustfmt-config-alist nil
+  "An alist of (KEY . VAL) pairs that are passed to rustfmt.
+
+KEY is a symbol that corresponds to a config value of rustfmt.
+VALUE is a string, an integer or a boolean."
+  :type '(alist :key-type symbol
+                :value-type (choice string integer boolean))
+  :group 'rustic)
+
 (defcustom rustic-lsp-setup-p t
   "Setup LSP related stuff automatically."
   :type 'boolean

--- a/rustic-compile.el
+++ b/rustic-compile.el
@@ -358,9 +358,9 @@ buffers are formatted after saving if turned on by `rustic-format-trigger'."
             (when (and saved-p (rustic-format-on-save-p) (eq major-mode 'rustic-mode))
               (let* ((file (buffer-file-name buffer))
                      (proc (rustic-format-start-process
-			    'rustic-format-file-sentinel
+                            'rustic-format-file-sentinel
                             :buffer buffer
-                            :command `(,rustic-rustfmt-bin ,file))))
+                            :files file)))
                 (while (eq (process-status proc) 'run)
                   (sit-for 0.1))))))))))
 

--- a/rustic-util.el
+++ b/rustic-util.el
@@ -189,7 +189,7 @@ were issues when using stdin for formatting."
              (file (buffer-file-name buf))
              (string (buffer-string)))
         (write-region string nil file nil 0)
-        (let ((command `(,rustic-rustfmt-bin ,file)))
+        (let ((command `(,rustic-rustfmt-bin ,file ,@rustic-rustfmt-args)))
           (setq proc (rustic-format-start-process 'rustic-format-file-sentinel
                                                   :buffer buf
                                                   :command command)))))

--- a/rustic-util.el
+++ b/rustic-util.el
@@ -69,7 +69,20 @@
 (defun rustic-format-start-process (sentinel &rest args)
   "Run rustfmt with ARGS.
 
-Use `:command' when formatting files and `:stdin' for strings."
+:buffer BUFFER -- BUFFER is the buffer that is being formatted.
+
+:stdin STRING -- STRING will be written to the standard input of rustfmt.
+When `:files' is non-nil, STRING will be ignored by rustfmt.
+
+:files FILES -- FILES is a string or list of strings that
+specify the input file or files to rustfmt.
+
+:command COMMAND -- COMMAND is a string or a list of strings.
+When COMMAND is a string, it is the program file name.
+When COMMAND is a list, it's `car' is the program file name
+and it's `cdr' is a list of arguments
+When COMMAND is nil, \(cons `rustic-rustfmt-bin' `rustic-rustfmt-args'\)
+will be used."
   (let* ((err-buf (get-buffer-create rustic-format-buffer-name))
          (inhibit-read-only t)
          (dir (rustic-buffer-workspace))

--- a/rustic-util.el
+++ b/rustic-util.el
@@ -78,11 +78,10 @@ When `:files' is non-nil, STRING will be ignored by rustfmt.
 specify the input file or files to rustfmt.
 
 :command COMMAND -- COMMAND is a string or a list of strings.
+When COMMAND is non-nil, it replaces the default command.
 When COMMAND is a string, it is the program file name.
 When COMMAND is a list, it's `car' is the program file name
-and it's `cdr' is a list of arguments
-When COMMAND is nil, \(cons `rustic-rustfmt-bin' `rustic-rustfmt-args'\)
-will be used."
+and it's `cdr' is a list of arguments."
   (let* ((err-buf (get-buffer-create rustic-format-buffer-name))
          (inhibit-read-only t)
          (dir (rustic-buffer-workspace))

--- a/rustic-util.el
+++ b/rustic-util.el
@@ -75,17 +75,17 @@ Use `:command' when formatting files and `:stdin' for strings."
          (dir (rustic-buffer-workspace))
          (buffer (plist-get args :buffer))
          (string (plist-get args :stdin))
-         (command (plist-get args :command)))
+         (command (plist-get args :command))
+         (file (and command (nth 1 command)))
+         (command (or command `(,rustic-rustfmt-bin ,@rustic-rustfmt-args))))
     (setq rustic-save-pos (point))
     (rustic-compilation-setup-buffer err-buf dir 'rustic-format-mode t)
-    (when command
-      (let ((file (nth 1 command)))
-        (unless (file-exists-p file)
-          (error (format "File %s does not exist." file)))))
+    (when (and file (not (file-exists-p file)))
+      (error (format "File %s does not exist." file)))
     (with-current-buffer err-buf
       (let ((proc (rustic-make-process :name rustic-format-process-name
                                        :buffer err-buf
-                                       :command (or command `(,rustic-rustfmt-bin))
+                                       :command command
                                        :filter #'rustic-compilation-filter
                                        :sentinel sentinel)))
         (setq next-error-last-buffer buffer)

--- a/rustic-util.el
+++ b/rustic-util.el
@@ -205,10 +205,9 @@ were issues when using stdin for formatting."
              (file (buffer-file-name buf))
              (string (buffer-string)))
         (write-region string nil file nil 0)
-        (let ((command `(,rustic-rustfmt-bin ,file ,@rustic-rustfmt-args)))
-          (setq proc (rustic-format-start-process 'rustic-format-file-sentinel
-                                                  :buffer buf
-                                                  :command command)))))
+        (setq proc (rustic-format-start-process 'rustic-format-file-sentinel
+                                                :buffer buf
+                                                :files file))))
     (while (eq (process-status proc) 'run)
       (sit-for 0.1))))
 

--- a/rustic-util.el
+++ b/rustic-util.el
@@ -91,7 +91,7 @@ will be used."
          (files  (plist-get args :files))
          (files (if (listp files) files (list files)))
          (command (or (plist-get args :command)
-                      (cons rustic-rustfmt-bin rustic-rustfmt-args)))
+                      (cons rustic-rustfmt-bin (rustic-compute-rustfmt-args))))
          (command (if (listp command) command (list command))))
     (setq rustic-save-pos (point))
     (rustic-compilation-setup-buffer err-buf dir 'rustic-format-mode t)

--- a/test/rustic-format-test.el
+++ b/test/rustic-format-test.el
@@ -71,7 +71,7 @@
 (ert-deftest rustic-test-format-file-with-tabs ()
   (let* ((string "fn main()      {()}")
          (formatted-string "fn main() {\n\t()\n}\n")
-         (rustic-rustfmt-args '("--config" "hard_tabs=true"))
+         (rustic-rustfmt-config-alist '((hard_tabs . t)))
          (dir (rustic-babel-generate-project t))
          (main (expand-file-name "main.rs" (concat dir "/src")))
          (buf (get-buffer-create "test")))

--- a/test/rustic-format-test.el
+++ b/test/rustic-format-test.el
@@ -57,7 +57,7 @@
     (let ((proc (rustic-format-start-process
                  'rustic-format-file-sentinel
                  :buffer buf
-                 :command `(,rustic-rustfmt-bin ,main))))
+                 :files main)))
       (while (eq (process-status proc) 'run)
         (sit-for 0.1)))
     (with-temp-buffer
@@ -66,7 +66,7 @@
     (should-error (rustic-format-start-process
                    'rustic-format-file-sentinel
                    :buffer "dummy"
-                   :command `(,rustic-rustfmt-bin "/tmp/nofile")))))
+                   :files "/tmp/nofile"))))
 
 (ert-deftest rustic-test-format-buffer-before-save ()
   (let* ((string "fn main()      {}")


### PR DESCRIPTION
This PR adds a `defcustom` called `rustic-rustfmt-args` that specifies a list of arguments to `rustfmt`.
This variable is honored by `rustic-format-buffer` and `rustic-format-start-process`.
I have decided to not make `rustic-cargo-fmt` honor this setting, because this function reformats the entire project and should therefore only obey the project-wide `rustfmt.toml`. Fixes #117.