### PR TITLE
Change Lighter to Rustic

### DIFF
--- a/rustic.el
+++ b/rustic.el
@@ -198,7 +198,7 @@ Use idomenu (imenu with `ido-mode') for best mileage.")
   "Keymap for Rust major mode.")
 
 ;;;###autoload
-(define-derived-mode rustic-mode prog-mode "Rust"
+(define-derived-mode rustic-mode prog-mode "Rustic"
   "Major mode for Rust code.
 
 \\{rustic-mode-map}"


### PR DESCRIPTION
Just a suggestion.

Rustic requires rust-mode to be installed, I think. So I have found a little inconsistency in loading (caused by own overly complex set up). Currently, it's not straight-forward to see visually which package is loaded and operational in a buffer.