### PR TITLE
Remove "-face" suffix from names of faces

### DIFF
--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -31,7 +31,10 @@ If nil then the project is simply created."
   "Face used for outdated crates."
   :group 'rustic)
 
-(defface rustic-cargo-outdated-upgrade-face
+(define-obsolete-face-alias 'rustic-cargo-outdated-upgrade-face
+  'rustic-cargo-outdated-upgrade "1.2")
+
+(defface rustic-cargo-outdated-upgrade
   '((t (:foreground "LightSeaGreen")))
   "Face used for crates marked for upgrade."
   :group 'rustic)
@@ -290,12 +293,12 @@ Execute process in PATH."
           (when (search-forward (elt crate 0))
             (replace-match (propertize (elt crate 0)
                                        'font-lock-face
-                                       'rustic-cargo-outdated-upgrade-face)))
+                                       'rustic-cargo-outdated-upgrade)))
           (goto-char (line-beginning-position))
           (when (search-forward (elt crate 1))
             (replace-match (propertize v
                                        'font-lock-face
-                                       'rustic-cargo-outdated-upgrade-face)))))
+                                       'rustic-cargo-outdated-upgrade)))))
       (tabulated-list-put-tag "U" t))))
 
 ;;;###autoload

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -21,6 +21,16 @@ If nil then the project is simply created."
   :type 'boolean
   :group 'rustic-cargo)
 
+(defvar rustic-cargo-outdated-face nil)
+(make-obsolete-variable 'rustic-cargo-outdated-face
+                        "use the face `rustic-cargo-outdated' instead."
+                        "1.2")
+
+(defface rustic-cargo-outdated
+  '((t (:foreground "red")))
+  "Face used for outdated crates."
+  :group 'rustic)
+
 (defface rustic-cargo-outdated-upgrade-face
   '((t (:foreground "LightSeaGreen")))
   "Face used for crates marked for upgrade."
@@ -147,11 +157,6 @@ When calling this function from `rustic-popup-mode', always use the value of
 
 ;;; Outdated
 
-(defcustom rustic-cargo-outdated-face "red"
-  "Face for upgradeable crates."
-  :type 'face
-  :group 'rustic)
-
 (defvar rustic-cargo-outdated-process-name "rustic-cargo-outdated-process")
 
 (defvar rustic-cargo-oudated-buffer-name "*cargo-outdated*")
@@ -264,9 +269,7 @@ Execute process in PATH."
                  ,project
                  ,(if (when (not (string-match "^-" compat))
                         (version< project compat))
-                      (propertize compat
-                                  'font-lock-face
-                                  `(:foreground ,rustic-cargo-outdated-face))
+                      (propertize compat 'font-lock-face 'rustic-cargo-outdated)
                     compat)
                  ,(nth 3 fields)
                  ,(nth 4 fields)

--- a/rustic-compile.el
+++ b/rustic-compile.el
@@ -47,40 +47,34 @@
 
 ;;; Faces
 
-(defcustom rustic-message-face
+(defface rustic-message-face
   '((t :inherit default))
   "Don't use `compilation-message-face', as ansi colors get messed up."
-  :type 'face
   :group 'rustic-compilation)
 
-(defcustom rustic-compilation-error-face
+(defface rustic-compilation-error-face
   '((t :inherit default))
   "Override `compilation-error-face' for rust compilation."
-  :type 'face
   :group 'rustic-compilation)
 
-(defcustom rustic-compilation-warning-face
+(defface rustic-compilation-warning-face
   '((t :inherit default))
   "Override `compilation-warning-face' for rust compilation."
-  :type 'face
   :group 'rustic-compilation)
 
-(defcustom rustic-compilation-info-face
+(defface rustic-compilation-info-face
   '((t :inherit default))
   "Override `compilation-info-face' for rust compilation."
-  :type 'face
   :group 'rustic-compilation)
 
-(defcustom rustic-compilation-line-face
+(defface rustic-compilation-line-face
   '((t :inherit default))
   "Override `compilation-line-face' for rust compilation."
-  :type 'face
   :group 'rustic-compilation)
 
-(defcustom rustic-compilation-column-face
+(defface rustic-compilation-column-face
   '((t :inherit default))
   "Override `compilation-column-face' for rust compilation."
-  :type 'face
   :group 'rustic-compilation)
 
 (defcustom rustic-ansi-faces ["black"
@@ -110,12 +104,12 @@
   "Rust compilation mode.
 
 Error matching regexes from compile.el are removed."
-  (setq-local compilation-message-face rustic-message-face)
-  (setq-local compilation-error-face rustic-compilation-error-face)
-  (setq-local compilation-warning-face rustic-compilation-warning-face)
-  (setq-local compilation-info-face rustic-compilation-info-face)
-  (setq-local compilation-column-face rustic-compilation-line-face)
-  (setq-local compilation-line-face rustic-compilation-column-face)
+  (setq-local compilation-message-face 'rustic-message-face)
+  (setq-local compilation-error-face   'rustic-compilation-error-face)
+  (setq-local compilation-warning-face 'rustic-compilation-warning-face)
+  (setq-local compilation-info-face    'rustic-compilation-info-face)
+  (setq-local compilation-column-face  'rustic-compilation-line-face)
+  (setq-local compilation-line-face    'rustic-compilation-column-face)
 
   (setq-local xterm-color-names-bright rustic-ansi-faces)
   (setq-local xterm-color-names rustic-ansi-faces)

--- a/rustic-compile.el
+++ b/rustic-compile.el
@@ -47,32 +47,45 @@
 
 ;;; Faces
 
-(defface rustic-message-face
+(define-obsolete-face-alias 'rustic-message-face
+  'rustic-message "1.2")
+(define-obsolete-face-alias 'rustic-compilation-error-face
+  'rustic-compilation-error "1.2")
+(define-obsolete-face-alias 'rustic-compilation-warning-face
+  'rustic-compilation-warning "1.2")
+(define-obsolete-face-alias 'rustic-compilation-info-face
+  'rustic-compilation-info "1.2")
+(define-obsolete-face-alias 'rustic-compilation-line-face
+  'rustic-compilation-line "1.2")
+(define-obsolete-face-alias 'rustic-compilation-column-face
+  'rustic-compilation-column "1.2")
+
+(defface rustic-message
   '((t :inherit default))
   "Don't use `compilation-message-face', as ansi colors get messed up."
   :group 'rustic-compilation)
 
-(defface rustic-compilation-error-face
+(defface rustic-compilation-error
   '((t :inherit default))
   "Override `compilation-error-face' for rust compilation."
   :group 'rustic-compilation)
 
-(defface rustic-compilation-warning-face
+(defface rustic-compilation-warning
   '((t :inherit default))
   "Override `compilation-warning-face' for rust compilation."
   :group 'rustic-compilation)
 
-(defface rustic-compilation-info-face
+(defface rustic-compilation-info
   '((t :inherit default))
   "Override `compilation-info-face' for rust compilation."
   :group 'rustic-compilation)
 
-(defface rustic-compilation-line-face
+(defface rustic-compilation-line
   '((t :inherit default))
   "Override `compilation-line-face' for rust compilation."
   :group 'rustic-compilation)
 
-(defface rustic-compilation-column-face
+(defface rustic-compilation-column
   '((t :inherit default))
   "Override `compilation-column-face' for rust compilation."
   :group 'rustic-compilation)

--- a/rustic-popup.el
+++ b/rustic-popup.el
@@ -26,12 +26,17 @@ The first element of each list contains a command's binding."
   :type 'list
   :group 'rustic-popup)
 
-(defface rustic-popup-key-face
+(define-obsolete-face-alias 'rustic-popup-key-face
+  'rustic-popup-key "1.2")
+(define-obsolete-face-alias 'rustic-popup-section-face
+  'rustic-popup-section "1.2")
+
+(defface rustic-popup-key
   '((t (:foreground "DeepSkyBlue")))
   "Face used for command shortcuts."
   :group 'rustic)
 
-(defface rustic-popup-section-face
+(defface rustic-popup-section
   '((t (:foreground "#f74c00")))
   "Face used for popup section description."
   :group 'rustic)
@@ -62,7 +67,7 @@ The first element of each list contains a command's binding."
   "Insert backtrace section."
   (let ((inhibit-read-only t)
         (prop (lambda (s)
-                (propertize s 'face 'rustic-popup-section-face))))
+                (propertize s 'face 'rustic-popup-section))))
     (insert (funcall prop "Backtrace: "))
     (cond
      ((string= rustic-compile-backtrace "0")
@@ -80,14 +85,15 @@ The first element of each list contains a command's binding."
       (erase-buffer)
       (rustic-popup-mode)
       (rustic-popup-insert-backtrace)
-      (insert (propertize "Commands: " 'face 'rustic-popup-section-face) "\n")
-      (insert " " (propertize "g" 'face 'rustic-popup-key-face)
+      (insert (propertize "Commands: " 'face 'rustic-popup-section) "\n")
+      (insert " " (propertize "g" 'face 'rustic-popup-key)
               "      " "recompile" "   " "\""
               (or compilation-arguments rustic-compile-command)
               "\"" "\n\n")
       (dolist (command rustic-popup-commands)
         (insert "\s")
-        (insert (propertize (char-to-string (nth 0 command)) 'face 'rustic-popup-key-face))
+        (insert (propertize (char-to-string (nth 0 command))
+                            'face 'rustic-popup-key))
         (insert "\s\s\s\s\s\s")
         (insert (nth 1 command))
         (when (and (string= (nth 1 command) "test")

--- a/rustic-racer.el
+++ b/rustic-racer.el
@@ -60,7 +60,10 @@ If nil, we will query $CARGO_HOME at runtime."
 
 ;;; Faces
 
-(defface rustic-racer-help-heading-face
+(define-obsolete-face-alias 'rustic-racer-help-heading-face
+  'rustic-racer-help-heading "1.2")
+
+(defface rustic-racer-help-heading
   '((t :weight bold))
   "Face for markdown headings in *Racer Help* buffers.")
 
@@ -88,7 +91,7 @@ Commands:
 
 (defun rustic-racer-header (text)
   "Helper function for adding text properties to TEXT."
-  (propertize text 'face 'rustic-racer-help-heading-face))
+  (propertize text 'face 'rustic-racer-help-heading))
 
 (defun rustic-racer-button-go-to-src (button)
   (rustic-racer-find-file

--- a/rustic.el
+++ b/rustic.el
@@ -85,22 +85,31 @@ to the function arguments.  When nil, `->' will be indented one level."
 
 ;;; Faces
 
-(defface rustic-unsafe-face
+(define-obsolete-face-alias 'rustic-unsafe-face
+  'rustic-unsafe "1.2")
+(define-obsolete-face-alias 'rustic-question-mark-face
+  'rustic-question-mark "1.2")
+(define-obsolete-face-alias 'rustic-builtin-formatting-macro-face
+  'rustic-builtin-formatting-macro "1.2")
+(define-obsolete-face-alias 'rustic-string-interpolation-face
+  'rustic-string-interpolation "1.2")
+
+(defface rustic-unsafe
   '((t :inherit font-lock-warning-face))
   "Face for the `unsafe' keyword."
   :group 'rustic)
 
-(defface rustic-question-mark-face
+(defface rustic-question-mark
   '((t :weight bold :inherit font-lock-builtin-face))
   "Face for the question mark operator."
   :group 'rustic)
 
-(defface rustic-builtin-formatting-macro-face
+(defface rustic-builtin-formatting-macro
   '((t :inherit font-lock-builtin-face))
   "Face for builtin formatting macros (print! &c.)."
   :group 'rustic)
 
-(defface rustic-string-interpolation-face
+(defface rustic-string-interpolation
   '((t :slant italic :inherit font-lock-string-face))
   "Face for interpolating braces in builtin formatting macro strings."
   :group 'rustic)
@@ -359,7 +368,7 @@ Does not match type annotations of the form \"foo::<\"."
      (,(regexp-opt rustic-special-types 'symbols) . font-lock-type-face)
 
      ;; The unsafe keyword
-     ("\\_<unsafe\\_>" . 'rustic-unsafe-face)
+     ("\\_<unsafe\\_>" . 'rustic-unsafe)
 
      ;; Attributes like `#[bar(baz)]` or `#![bar(baz)]` or `#[bar = "baz"]`
      (,(rustic-re-grab (concat "#\\!?\\[" rustic-re-ident "[^]]*\\]"))
@@ -369,22 +378,22 @@ Does not match type annotations of the form \"foo::<\"."
      (,(concat (rustic-re-grab (concat (regexp-opt rustic-builtin-formatting-macros) "!"))
                rustic-formatting-macro-opening-re
                rustic-start-of-string-re)
-      (1 'rustic-builtin-formatting-macro-face)
+      (1 'rustic-builtin-formatting-macro)
       (rustic-string-interpolation-matcher
        (rustic-end-of-string)
        nil
-       (0 'rustic-string-interpolation-face t nil)))
+       (0 'rustic-string-interpolation t nil)))
 
      ;; write! macro
      (,(concat (rustic-re-grab "write\\(ln\\)?!")
                rustic-formatting-macro-opening-re
                "[[:space:]]*[^\"]+,[[:space:]]*"
                rustic-start-of-string-re)
-      (1 'rustic-builtin-formatting-macro-face)
+      (1 'rustic-builtin-formatting-macro)
       (rustic-string-interpolation-matcher
        (rustic-end-of-string)
        nil
-       (0 'rustic-string-interpolation-face t nil)))
+       (0 'rustic-string-interpolation t nil)))
 
      ;; Syntax extension invocations like `foo!`, highlight including the !
      (,(concat (rustic-re-grab (concat rustic-re-ident "!")) "[({[:space:][]")
@@ -412,7 +421,7 @@ Does not match type annotations of the form \"foo::<\"."
      (,(concat "'" (rustic-re-grab rustic-re-ident) "[^']") 1 font-lock-variable-name-face)
 
      ;; Question mark operator
-     ("\\?" . 'rustic-question-mark-face)
+     ("\\?" . 'rustic-question-mark)
      )
 
    ;; Ensure we highlight `Foo` in `struct Foo` as a type.

--- a/test/rustic-font-lock-test.el
+++ b/test/rustic-font-lock-test.el
@@ -401,13 +401,13 @@ this_is_not_a_string();)"
   "Ensure question mark operator is highlighted."
   (rustic-test-font-lock
    "?"
-   '("?" rustic-question-mark-face))
+   '("?" rustic-question-mark))
   (rustic-test-font-lock
    "foo\(\)?;"
-   '("?" rustic-question-mark-face))
+   '("?" rustic-question-mark))
   (rustic-test-font-lock
    "foo\(bar\(\)?\);"
-   '("?" rustic-question-mark-face))
+   '("?" rustic-question-mark))
   (rustic-test-font-lock
    "\"?\""
    '("\"?\"" font-lock-string-face))
@@ -427,7 +427,7 @@ this_is_not_a_string();)"
   (rustic-test-font-lock
    "foo\(\"?\"\)?;"
    '("\"?\"" font-lock-string-face
-     "?" rustic-question-mark-face)))
+     "?" rustic-question-mark)))
 
 (ert-deftest rustic-test-default-context-sensitive ()
   (rustic-test-font-lock
@@ -488,21 +488,21 @@ this_is_not_a_string();)"
 (ert-deftest rustic-write-macro-font-lock ()
   (rustic-test-font-lock
    "write!(f, \"abcd {0}}} efgh {1}\", foo, bar); { /* no-op */ }"
-   '("write!" rustic-builtin-formatting-macro-face
+   '("write!" rustic-builtin-formatting-macro
      "\"abcd " font-lock-string-face
-     "{0}" rustic-string-interpolation-face
+     "{0}" rustic-string-interpolation
      "}} efgh " font-lock-string-face
-     "{1}" rustic-string-interpolation-face
+     "{1}" rustic-string-interpolation
      "\"" font-lock-string-face
      "/* " font-lock-comment-delimiter-face
      "no-op */" font-lock-comment-face))
   (rustic-test-font-lock
    "writeln!(f, \"abcd {0}}} efgh {1}\", foo, bar); { /* no-op */ }"
-   '("writeln!" rustic-builtin-formatting-macro-face
+   '("writeln!" rustic-builtin-formatting-macro
      "\"abcd " font-lock-string-face
-     "{0}" rustic-string-interpolation-face
+     "{0}" rustic-string-interpolation
      "}} efgh " font-lock-string-face
-     "{1}" rustic-string-interpolation-face
+     "{1}" rustic-string-interpolation
      "\"" font-lock-string-face
      "/* " font-lock-comment-delimiter-face
      "no-op */" font-lock-comment-face)))
@@ -513,21 +513,21 @@ this_is_not_a_string();)"
   ;; is ignored
   (rustic-test-font-lock
    "print!(\"\"); { /* print!(\"\"); */ }"
-   '("print!" rustic-builtin-formatting-macro-face
+   '("print!" rustic-builtin-formatting-macro
      "\"\"" font-lock-string-face
      "/* " font-lock-comment-delimiter-face
      "print!(\"\"); */" font-lock-comment-face))
   ;; ;; with newline directly following delimiter
   ;; (rustic-test-font-lock
   ;;  "print!(\n\"\"\n); { /* print!(\"\"); */ }"
-  ;;  '("print!" rustic-builtin-formatting-macro-face
+  ;;  '("print!" rustic-builtin-formatting-macro
   ;;    "\"\"" font-lock-string-face
   ;;    "/* " font-lock-comment-delimiter-face
   ;;    "print!(\"\"); */" font-lock-comment-face))
   ;; ;; with empty println!()
   ;; (rustic-test-font-lock
   ;;  "println!(); { /* println!(); */ }"
-  ;;  '("println!" rustic-builtin-formatting-macro-face
+  ;;  '("println!" rustic-builtin-formatting-macro
   ;;    "/* " font-lock-comment-delimiter-face
   ;;    "println!(); */" font-lock-comment-face))
   (rustic-test-font-lock
@@ -538,145 +538,145 @@ this_is_not_a_string();)"
   ;; other delimiters
   (rustic-test-font-lock
    "print!{\"\"}; { /* no-op */ }"
-   '("print!" rustic-builtin-formatting-macro-face
+   '("print!" rustic-builtin-formatting-macro
      "\"\"" font-lock-string-face
      "/* " font-lock-comment-delimiter-face
      "no-op */" font-lock-comment-face))
   ;; other delimiters
   (rustic-test-font-lock
    "print![\"\"]; { /* no-op */ }"
-   '("print!" rustic-builtin-formatting-macro-face
+   '("print!" rustic-builtin-formatting-macro
      "\"\"" font-lock-string-face
      "/* " font-lock-comment-delimiter-face
      "no-op */" font-lock-comment-face))
   ;; no interpolation
   (rustic-test-font-lock
    "print!(\"abcd\"); { /* no-op */ }"
-   '("print!" rustic-builtin-formatting-macro-face
+   '("print!" rustic-builtin-formatting-macro
      "\"abcd\"" font-lock-string-face
      "/* " font-lock-comment-delimiter-face
      "no-op */" font-lock-comment-face))
   ;; only interpolation
   (rustic-test-font-lock
    "print!(\"{}\"); { /* no-op */ }"
-   '("print!" rustic-builtin-formatting-macro-face
+   '("print!" rustic-builtin-formatting-macro
      "\"" font-lock-string-face
-     "{}" rustic-string-interpolation-face
+     "{}" rustic-string-interpolation
      "\"" font-lock-string-face
      "/* " font-lock-comment-delimiter-face
      "no-op */" font-lock-comment-face))
   ;; text + interpolation
   (rustic-test-font-lock
    "print!(\"abcd {}\", foo); { /* no-op */ }"
-   '("print!" rustic-builtin-formatting-macro-face
+   '("print!" rustic-builtin-formatting-macro
      "\"abcd " font-lock-string-face
-     "{}" rustic-string-interpolation-face
+     "{}" rustic-string-interpolation
      "\"" font-lock-string-face
      "/* " font-lock-comment-delimiter-face
      "no-op */" font-lock-comment-face))
   ;; text + interpolation with specification
   (rustic-test-font-lock
    "print!(\"abcd {0}\", foo); { /* no-op */ }"
-   '("print!" rustic-builtin-formatting-macro-face
+   '("print!" rustic-builtin-formatting-macro
      "\"abcd " font-lock-string-face
-     "{0}" rustic-string-interpolation-face
+     "{0}" rustic-string-interpolation
      "\"" font-lock-string-face
      "/* " font-lock-comment-delimiter-face
      "no-op */" font-lock-comment-face))
   ;; text + interpolation with specification and escape
   (rustic-test-font-lock
    "print!(\"abcd {0}}}\", foo); { /* no-op */ }"
-   '("print!" rustic-builtin-formatting-macro-face
+   '("print!" rustic-builtin-formatting-macro
      "\"abcd " font-lock-string-face
-     "{0}" rustic-string-interpolation-face
+     "{0}" rustic-string-interpolation
      "}}\"" font-lock-string-face
      "/* " font-lock-comment-delimiter-face
      "no-op */" font-lock-comment-face))
   ;; multiple pairs
   (rustic-test-font-lock
    "print!(\"abcd {0} efgh {1}\", foo, bar); { /* no-op */ }"
-   '("print!" rustic-builtin-formatting-macro-face
+   '("print!" rustic-builtin-formatting-macro
      "\"abcd " font-lock-string-face
-     "{0}" rustic-string-interpolation-face
+     "{0}" rustic-string-interpolation
      " efgh " font-lock-string-face
-     "{1}" rustic-string-interpolation-face
+     "{1}" rustic-string-interpolation
      "\"" font-lock-string-face
      "/* " font-lock-comment-delimiter-face
      "no-op */" font-lock-comment-face))
   ;; println
   (rustic-test-font-lock
    "println!(\"abcd {0} efgh {1}\", foo, bar); { /* no-op */ }"
-   '("println!" rustic-builtin-formatting-macro-face
+   '("println!" rustic-builtin-formatting-macro
      "\"abcd " font-lock-string-face
-     "{0}" rustic-string-interpolation-face
+     "{0}" rustic-string-interpolation
      " efgh " font-lock-string-face
-     "{1}" rustic-string-interpolation-face
+     "{1}" rustic-string-interpolation
      "\"" font-lock-string-face
      "/* " font-lock-comment-delimiter-face
      "no-op */" font-lock-comment-face))
   ;; eprint
   (rustic-test-font-lock
    "eprint!(\"abcd {0} efgh {1}\", foo, bar); { /* no-op */ }"
-   '("eprint!" rustic-builtin-formatting-macro-face
+   '("eprint!" rustic-builtin-formatting-macro
      "\"abcd " font-lock-string-face
-     "{0}" rustic-string-interpolation-face
+     "{0}" rustic-string-interpolation
      " efgh " font-lock-string-face
-     "{1}" rustic-string-interpolation-face
+     "{1}" rustic-string-interpolation
      "\"" font-lock-string-face
      "/* " font-lock-comment-delimiter-face
      "no-op */" font-lock-comment-face))
   ;; eprintln
   (rustic-test-font-lock
    "eprintln!(\"abcd {0} efgh {1}\", foo, bar); { /* no-op */ }"
-   '("eprintln!" rustic-builtin-formatting-macro-face
+   '("eprintln!" rustic-builtin-formatting-macro
      "\"abcd " font-lock-string-face
-     "{0}" rustic-string-interpolation-face
+     "{0}" rustic-string-interpolation
      " efgh " font-lock-string-face
-     "{1}" rustic-string-interpolation-face
+     "{1}" rustic-string-interpolation
      "\"" font-lock-string-face
      "/* " font-lock-comment-delimiter-face
      "no-op */" font-lock-comment-face))
   ;; format
   (rustic-test-font-lock
    "format!(\"abcd {0} efgh {1}\", foo, bar); { /* no-op */ }"
-   '("format!" rustic-builtin-formatting-macro-face
+   '("format!" rustic-builtin-formatting-macro
      "\"abcd " font-lock-string-face
-     "{0}" rustic-string-interpolation-face
+     "{0}" rustic-string-interpolation
      " efgh " font-lock-string-face
-     "{1}" rustic-string-interpolation-face
+     "{1}" rustic-string-interpolation
      "\"" font-lock-string-face
      "/* " font-lock-comment-delimiter-face
      "no-op */" font-lock-comment-face))
   ;; print + raw string
   (rustic-test-font-lock
    "format!(r\"abcd {0} efgh {1}\", foo, bar); { /* no-op */ }"
-   '("format!" rustic-builtin-formatting-macro-face
+   '("format!" rustic-builtin-formatting-macro
      "r\"abcd " font-lock-string-face
-     "{0}" rustic-string-interpolation-face
+     "{0}" rustic-string-interpolation
      " efgh " font-lock-string-face
-     "{1}" rustic-string-interpolation-face
+     "{1}" rustic-string-interpolation
      "\"" font-lock-string-face
      "/* " font-lock-comment-delimiter-face
      "no-op */" font-lock-comment-face))
   ;; print + raw string with hash
   (rustic-test-font-lock
    "format!(r#\"abcd {0} efgh {1}\"#, foo, bar); { /* no-op */ }"
-   '("format!" rustic-builtin-formatting-macro-face
+   '("format!" rustic-builtin-formatting-macro
      "r#\"abcd " font-lock-string-face
-     "{0}" rustic-string-interpolation-face
+     "{0}" rustic-string-interpolation
      " efgh " font-lock-string-face
-     "{1}" rustic-string-interpolation-face
+     "{1}" rustic-string-interpolation
      "\"#" font-lock-string-face
      "/* " font-lock-comment-delimiter-face
      "no-op */" font-lock-comment-face))
   ;; print + raw string with two hashes
   (rustic-test-font-lock
    "format!(r##\"abcd {0} efgh {1}\"##, foo, bar); { /* no-op */ }"
-   '("format!" rustic-builtin-formatting-macro-face
+   '("format!" rustic-builtin-formatting-macro
      "r##\"abcd " font-lock-string-face
-     "{0}" rustic-string-interpolation-face
+     "{0}" rustic-string-interpolation
      " efgh " font-lock-string-face
-     "{1}" rustic-string-interpolation-face
+     "{1}" rustic-string-interpolation
      "\"##" font-lock-string-face
      "/* " font-lock-comment-delimiter-face
      "no-op */" font-lock-comment-face)))


### PR DESCRIPTION
As mentioned at (info "(emacs)Defining Faces") "[the name of a face]
should not end in "-face" (that would be redundant).  For historic
reasons a few built-in faces actually do end with "-face" and it so
happens that many of our faces are closely related to just those
`font-lock` and `compilation` faces and that probably inspired our
use of the suffix.  Even so, we should stop now.

PS: I did not base this on the latest tip of `master` because there is a recent regression, which I did not wish to investigate.  `make` should tell you about that issue.