### PR TITLE
Prompt user to install (some of the) dependencies for rustic doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,10 +393,9 @@ With some setup, it is possible to read rust documentation inside Emacs!
 
 * Install Pandoc https://pandoc.org/installing.html
 * Install cargo https://doc.rust-lang.org/cargo/getting-started/installation.html
-* Install ripgrep with `cargo install ripgrep` or one of the alternatives: https://github.com/BurntSushi/ripgrep#installation (Optional, but highly recommended)
-* Install cargo-makedocs by running `cargo install cargo-makedocs` https://github.com/Bunogi/cargo-makedocs
-* Install fd with `cargo install fd`, or your package manager
 * Install helm-ag https://github.com/emacsorphanage/helm-ag (Optional, but highly recommended)
+If you do not have them, you will be prompted to install `fd-find`, `ripgrep` and `cargo-makedocs` when you run `rustic-doc-setup`. 
+`ripgrep` is optional but highly recommended.
 If helm-ag and ripgrep is installed, those will be used by default.
 If only ripgrep is installed, it will be used with the emacs `grep` command.
 If neither is installed, the emacs `grep` command will use `grep`, like in the good old days.

--- a/rustic-doc.el
+++ b/rustic-doc.el
@@ -53,7 +53,7 @@ All projects and std by default, otherwise last open project and std.")
   "The default search command when using helm-ag.
 Needs to be a function because of its reliance on
 `rustic-doc-current-project'"
-  (concat "rg --smart-case --no-heading --color=never --line-number --pcre2" (if rustic-doc-current-project "-L" "")))
+  (concat "rg --smart-case --no-heading --color=never --line-number --pcre2" (if rustic-doc-current-project " -L" "")))
 
 (defcustom rustic-doc-rg-search-command 'rustic-doc-default-rg-search-command
   "The default command string to pass helm-ag when searching."

--- a/rustic-doc.el
+++ b/rustic-doc.el
@@ -247,16 +247,18 @@ If the user has not visited a project, returns the main doc directory."
 
 (defun rustic-doc-install-deps ()
   "Install dependencies with Cargo."
-  (let ((missing-rg (not  (executable-find "rg")))
-        (missing-fd (not  (executable-find "fd")))
-        (missing-makedocs (not  (executable-find "cargo-makedocs"))))
-    (when (and  (or missing-fd missing-makedocs missing-rg) (y-or-n-p "Missing some dependencies for rustic doc, install them? "))
-      (when missing-fd
-        (async-start-process "install-fd" "cargo" nil "install" "fd-find"))
-      (when missing-rg
-        (async-start-process "install-rg" "cargo" nil "install" "ripgrep"))
-      (when missing-makedocs
-        (async-start-process "install-makedocs" "cargo" nil "install" "cargo-makedocs")))))
+  (if (not (executable-find "cargo"))
+      (message "You need to have cargo installed to use rustic-doc")
+    (let ((missing-rg (not (executable-find "rg")))
+          (missing-fd (not (executable-find "fd")))
+          (missing-makedocs (not (executable-find "cargo-makedocs"))))
+      (when (and  (or missing-fd missing-makedocs missing-rg) (y-or-n-p "Missing some dependencies for rustic doc, install them? "))
+        (when missing-fd
+          (async-start-process "install-fd" "cargo" nil "install" "fd-find"))
+        (when missing-rg
+          (async-start-process "install-rg" "cargo" nil "install" "ripgrep"))
+        (when missing-makedocs
+          (async-start-process "install-makedocs" "cargo" nil "install" "cargo-makedocs"))))))
 
 
 ;;;###autoload

--- a/rustic-doc.el
+++ b/rustic-doc.el
@@ -171,8 +171,6 @@ it doesn't manage to find what you're looking for, try `rustic-doc-dumb-search'.
       (rustic-doc-create-project-dir))
     (funcall rustic-doc-search-function search-dir regexed-search-term)))
 
-;; (rustic-doc--helm-ag-search (rustic-doc--project-doc-dest) "^(?!.*impl)^\\*+[^-*(<]*enum[^-*(<]*option")
-
 (defun rustic-doc--update-current-project ()
   "Update `rustic-doc-current-project' if editing a rust file, otherwise leave it."
   (when (and lsp-mode
@@ -247,11 +245,26 @@ If the user has not visited a project, returns the main doc directory."
                                  (rustic-doc--project-doc-dest)))))
     (message "Could not find project to convert. Visit a rust project first! (Or activate rustic-doc-mode if you are in one)")))
 
+(defun rustic-doc-install-deps ()
+  "Install dependencies with Cargo."
+  (let ((missing-rg (not  (executable-find "rg")))
+        (missing-fd (not  (executable-find "fd")))
+        (missing-makedocs (not  (executable-find "cargo-makedocs"))))
+    (when (and  (or missing-fd missing-makedocs missing-rg) (y-or-n-p "Missing some dependencies for rustic doc, install them? "))
+      (when missing-fd
+        (async-start-process "install-fd" "cargo" nil "install" "fd-find"))
+      (when missing-rg
+        (async-start-process "install-rg" "cargo" nil "install" "ripgrep"))
+      (when missing-makedocs
+        (async-start-process "install-makedocs" "cargo" nil "install" "cargo-makedocs")))))
+
+
 ;;;###autoload
 (defun rustic-doc-setup ()
   "Setup or update rustic-doc filter and convert script. Convert std."
   (interactive)
   (rustic-doc--install-resources)
+  (rustic-doc-install-deps)
   (message "Setup is converting the standard library")
   (delete-directory (concat rustic-doc-save-loc "/std")
                     t)

--- a/rustic-doc.el
+++ b/rustic-doc.el
@@ -53,7 +53,7 @@ All projects and std by default, otherwise last open project and std.")
   "The default search command when using helm-ag.
 Needs to be a function because of its reliance on
 `rustic-doc-current-project'"
-  (concat "rg --smart-case --no-heading --color=never --line-number --pcre2" (if rustic-doc-current-project " -L" "")))
+  (concat "rg --smart-case --no-heading --color=never --line-number " (if rustic-doc-current-project " -L" "")))
 
 (defcustom rustic-doc-rg-search-command 'rustic-doc-default-rg-search-command
   "The default command string to pass helm-ag when searching."
@@ -151,7 +151,7 @@ it doesn't manage to find what you're looking for, try `rustic-doc-dumb-search'.
                     (progn
                       (setq current-prefix-arg nil)
                       "^\\*")
-                  "^(?!.*impl)^\\*+"))  ; Do not match if it's an impl
+                  "^\\*+"))
          ;; This seq-reduce turns `enum option' into (kind of) `enum.*option', which lets there be chars between the searched words
          (regexed-search-term (concat regex
                                         ; Regex explanation


### PR DESCRIPTION
Also removes the requirement of PCRE2. This changes the search results slightly but apparently, the rg installed with cargo does not have support for it. Hopefully, it's a worthwhile tradeoff.