### PR TITLE
Add missing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ The rustic commands can be called with prefix `C-u` if you want to modify the pa
 - `rustic-cargo-add`     Add crate to Cargo.toml using 'cargo add'
 - `rustic-cargo-rm`      Remove crate from Cargo.toml using 'cargo rm'
 - `rustic-cargo-upgrade`  Upgrade dependencies as specified in the local manifest file using 'cargo upgrade'
+- `rustic-cargo-add-missing-imports ` Add the missing imports for the current buffer to `cargo.toml`. This function requires `lsp-mode`.
 
 ### Test
 

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -446,7 +446,7 @@ If running with prefix command `C-u', read whole command from minibuffer."
                       (concat "cargo add " (read-from-minibuffer "Crate: ")))))
       (rustic-run-cargo-command command))))
 
-(defun rustic-add-missing-import ()
+(defun rustic-cargo-add-missing-import ()
   "Add missing imports to Cargo.toml."
   (interactive)
   (let ((missing-imports (seq-reduce (lambda (missing-crates errortable)

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -446,6 +446,13 @@ If running with prefix command `C-u', read whole command from minibuffer."
                       (concat "cargo add " (read-from-minibuffer "Crate: ")))))
       (rustic-run-cargo-command command))))
 
+(defun rustic-add-missing-import()
+    "Add missing imports to cargo.toml."
+  (interactive)
+  (dolist (errortable (gethash (buffer-file-name) (lsp-diagnostics)))
+    (when (string= "E0432" (gethash "code" errortable))
+      (message "missing %s" (nth 3  (split-string  (gethash "message" errortable) "`"))))))
+
 ;;;###autoload
 (defun rustic-cargo-rm (&optional arg)
   "Remove crate from Cargo.toml using 'cargo rm'.

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -446,7 +446,7 @@ If running with prefix command `C-u', read whole command from minibuffer."
                       (concat "cargo add " (read-from-minibuffer "Crate: ")))))
       (rustic-run-cargo-command command))))
 
-(defun rustic-cargo-add-missing-import ()
+(defun rustic-cargo-add-missing-imports ()
   "Add missing imports to Cargo.toml."
   (interactive)
   (let ((missing-imports (seq-reduce (lambda (missing-crates errortable)
@@ -454,7 +454,9 @@ If running with prefix command `C-u', read whole command from minibuffer."
                                            (cons (nth 3 (split-string (gethash "message" errortable) "`")) missing-crates)
                                          missing-crates))
                                      (gethash (buffer-file-name) (lsp-diagnostics t)) '())))
-    missing-imports) )
+
+    (rustic-run-cargo-command (format  "cargo add %s" (mapconcat 'identity  missing-imports " ")))))
+
 
 ;;;###autoload
 (defun rustic-cargo-rm (&optional arg)

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -447,16 +447,20 @@ If running with prefix command `C-u', read whole command from minibuffer."
       (rustic-run-cargo-command command))))
 
 (defun rustic-cargo-add-missing-imports ()
-  "Add missing imports to Cargo.toml."
+  "Add missing imports to Cargo.toml.
+Adds all missing imports by default.
+Use with 'prefix-arg` to select imports to add."
   (interactive)
-  (let ((missing-imports (seq-reduce (lambda (missing-crates errortable)
-                                       (if (string= "E0432" (gethash "code" errortable))
-                                           (cons (nth 3 (split-string (gethash "message" errortable) "`")) missing-crates)
-                                         missing-crates))
-                                     (gethash (buffer-file-name) (lsp-diagnostics t)) '())))
-
-    (rustic-run-cargo-command (format  "cargo add %s" (mapconcat 'identity  missing-imports " ")))))
-
+  (let ((missing-imports (delete-dups
+                          (seq-reduce (lambda (missing-crates errortable)
+                                        (if (string= "E0432" (gethash "code" errortable))
+                                            (cons (nth 3 (split-string (gethash "message" errortable) "`")) missing-crates)
+                                          missing-crates))
+                                      (gethash (buffer-file-name) (lsp-diagnostics t)) '()))))
+    (rustic-run-cargo-command (format  "cargo add %s"
+                                       (if current-prefix-arg
+                                           (completing-read "Select import to add to Cargo.toml" missing-imports)
+                                         (mapconcat 'identity  missing-imports " "))))))
 
 ;;;###autoload
 (defun rustic-cargo-rm (&optional arg)

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -451,16 +451,19 @@ If running with prefix command `C-u', read whole command from minibuffer."
 Adds all missing imports by default.
 Use with 'prefix-arg` to select imports to add."
   (interactive)
-  (let ((missing-imports (delete-dups
-                          (seq-reduce (lambda (missing-crates errortable)
-                                        (if (string= "E0432" (gethash "code" errortable))
-                                            (cons (nth 3 (split-string (gethash "message" errortable) "`")) missing-crates)
-                                          missing-crates))
-                                      (gethash (buffer-file-name) (lsp-diagnostics t)) '()))))
-    (rustic-run-cargo-command (format  "cargo add %s"
-                                       (if current-prefix-arg
-                                           (completing-read "Select import to add to Cargo.toml" missing-imports)
-                                         (mapconcat 'identity  missing-imports " "))))))
+  (when (rustic-cargo-edit-installed-p)
+    (let ((missing-imports (delete-dups
+                            (seq-reduce (lambda (missing-crates errortable)
+                                          (if (string= "E0432" (gethash "code" errortable))
+                                              (cons (nth 3 (split-string (gethash "message" errortable) "`")) missing-crates)
+                                            missing-crates))
+                                        (gethash (buffer-file-name) (lsp-diagnostics t)) '()))))
+      (if missing-imports
+          (rustic-run-cargo-command (format  "cargo add %s"
+                                             (if current-prefix-arg
+                                                 (completing-read "Select import to add to Cargo.toml" missing-imports)
+                                               (mapconcat 'identity  missing-imports " "))))
+        (message "Couldn't find any imports to add. If this was a mistake, make sure your language server is running properly.")))))
 
 ;;;###autoload
 (defun rustic-cargo-rm (&optional arg)

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -446,12 +446,15 @@ If running with prefix command `C-u', read whole command from minibuffer."
                       (concat "cargo add " (read-from-minibuffer "Crate: ")))))
       (rustic-run-cargo-command command))))
 
-(defun rustic-add-missing-import()
-    "Add missing imports to cargo.toml."
+(defun rustic-add-missing-import ()
+  "Add missing imports to Cargo.toml."
   (interactive)
-  (dolist (errortable (gethash (buffer-file-name) (lsp-diagnostics)))
-    (when (string= "E0432" (gethash "code" errortable))
-      (message "missing %s" (nth 3  (split-string  (gethash "message" errortable) "`"))))))
+  (let ((missing-imports (seq-reduce (lambda (missing-crates errortable)
+                                       (if (string= "E0432" (gethash "code" errortable))
+                                           (cons (nth 3 (split-string (gethash "message" errortable) "`")) missing-crates)
+                                         missing-crates))
+                                     (gethash (buffer-file-name) (lsp-diagnostics t)) '())))
+    missing-imports) )
 
 ;;;###autoload
 (defun rustic-cargo-rm (&optional arg)


### PR DESCRIPTION
For https://github.com/brotzeit/rustic/issues/150
`missing-imports` is just a list at the moment. What is the preferred way to prompt the user to select one of them? An alternative would be to just add all missing dependencies. I'm not sure how often a user would input several missing dependencies and then only want to add a subset of them. And in those cases, you could just not run `rustic-cargo-add-missing-import`. 