### PR TITLE
Improve docs for edition = "2018" rustfmt requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Customization:
 
 ### edition 2018
 
-You have to put `edition = "2018"` in a `rustfmt.toml`.
+If you are struggling with errors relating to the rust edition in `cargo.toml`, this may in fact be a problem with `rustfmt` and its default settings. To solve this, *even though the error message mentions `cargo.toml`*, you you have to put `edition = "2018"` in a `rustfmt.toml`. [See here for more info](https://github.com/rust-lang/rustfmt/issues/4454).
 
 ## LSP
 


### PR DESCRIPTION
Hi there,

I had an issue with rustic which had been documented, but which I couldn't find! I thought I'd improve the message a little and link to a [bug report I've submitted ](https://github.com/rust-lang/rustfmt/issues/4454)on `rustfmt` to encourage a more intuitive error message.