### PR TITLE
Use Tramp aware calls

### DIFF
--- a/rustic-compile.el
+++ b/rustic-compile.el
@@ -198,12 +198,14 @@ Set environment variables for rust process."
                                (format "TERM=%s" "ansi")
                                (format "RUST_BACKTRACE=%s" rustic-compile-backtrace))
                               process-environment)))
-    (make-process :name (plist-get args :name)
-                  :buffer (plist-get args :buffer)
-                  :command (plist-get args :command)
-                  :filter (plist-get args :filter)
-                  :sentinel (plist-get args :sentinel)
-                  :coding 'utf-8-emacs-unix)))
+    (let ((process (apply
+                    #'start-file-process (plist-get args :name)
+                    (plist-get args :buffer)
+                    (plist-get args :command))))
+      (set-process-filter process (plist-get args :filter))
+      (set-process-sentinel process (plist-get args :sentinel))
+      (set-process-coding-system process 'utf-8-emacs-unix 'utf-8-emacs-unix)
+      process)))
 
 (defun rustic-compilation-setup-buffer (buf dir mode &optional no-mode-line)
   "Prepare BUF for compilation process."

--- a/rustic-flycheck.el
+++ b/rustic-flycheck.el
@@ -45,7 +45,7 @@ targets could be found."
   (let ((process-output-as-json
          (lambda (program &rest args)
            (with-temp-buffer
-             (let ((code-or-signal (apply 'call-process program nil '(t nil) nil args)))
+             (let ((code-or-signal (apply 'process-file program nil '(t nil) nil args)))
                (unless (equal code-or-signal 0)
                  ;; Prevent from displaying "JSON readtable error".
                  (let* ((args (combine-and-quote-strings (cons program args)))
@@ -92,7 +92,7 @@ the closest matching target, or nil if no targets could be found.
 See http://doc.crates.io/manifest.html#the-project-layout for a
 description of the conventional Cargo project layout."
   (-when-let* ((workspace (rustic-buffer-workspace t))
-               (manifest (concat workspace "Cargo.toml"))
+               (manifest (file-local-name (concat workspace "Cargo.toml")))
                (packages (rustic-flycheck-get-cargo-targets manifest))
                (targets (-flatten-n 1 packages)))
     (let ((target


### PR DESCRIPTION
This tweaks a couple of calls so that rustic works with cargo, etc on a remote machine.  As far as I can tell it doesn't have any effect on a more conventional local setup.