### PR TITLE
Missing imports eglot

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ The rustic commands can be called with prefix `C-u` if you want to modify the pa
 - `rustic-cargo-add`     Add crate to Cargo.toml using 'cargo add'
 - `rustic-cargo-rm`      Remove crate from Cargo.toml using 'cargo rm'
 - `rustic-cargo-upgrade`  Upgrade dependencies as specified in the local manifest file using 'cargo upgrade'
-- `rustic-cargo-add-missing-imports ` Add the missing imports for the current buffer to `cargo.toml`. This function requires `lsp-mode`.
+- `rustic-cargo-add-missing-imports ` Add the missing imports for the current buffer to `cargo.toml`. This function requires `lsp-mode` or `eglot`.
 
 ### Test
 

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -472,7 +472,7 @@ Adds all missing imports by default.
 Use with 'prefix-arg` to select imports to add."
   (interactive)
   (when (rustic-cargo-edit-installed-p)
-    (if-let ((missing-imports (if lsp-mode
+    (if-let ((missing-imports (if (ignore-error lsp-mode)
                                   (rustic-cargo--lsp-missing-imports)
                                 (rustic-cargo--eglot-missing-imports))))
         (rustic-run-cargo-command (format  "cargo add %s"

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -446,25 +446,15 @@ If running with prefix command `C-u', read whole command from minibuffer."
                       (concat "cargo add " (read-from-minibuffer "Crate: ")))))
       (rustic-run-cargo-command command))))
 
-
-;; (:code "E0432" :message "unresolved import `aosenuh`\nno `aosenuh` external crate" :range
-;; (:end
-;;  (:character 11 :line 0)
-;;  :start
-;;  (:character 4 :line 0))
-;; :severity 1 :source "rustc")
-;;
-(defun rustic-cargo-add-missing-imports-eglot ()
-  "Quiet doctor."
-  (interactive)
-  (seq-reduce (lambda (missing-crates clstruct)
-                (when (and  (flymake--diag-p clstruct)
-                            (string-match-p
-                             (regexp-quote "unresolved import `")
-                             (format "%s" (flymake--diag-text clstruct))))
-                  (progn
-                    (message "missing crate: %s" (nth 3 (split-string (flymake--diag-text clstruct) "`"))))))
-              eglot--unreported-diagnostics '()))
+(defun rustic-cargo--eglot-missing-imports ()
+  (delete-dups (seq-reduce (lambda (missing-crates clstruct)
+                             (if (and  (flymake--diag-p clstruct)
+                                       (string-match-p
+                                        (regexp-quote "unresolved import `")
+                                        (format "%s" (flymake--diag-text clstruct))))
+                                 (cons (nth 3 (split-string (flymake--diag-text clstruct) "`")) missing-crates)
+                               missing-crates))
+                           eglot--unreported-diagnostics '())))
 
 (defun rustic-cargo-add-missing-imports ()
   "Add missing imports to Cargo.toml.

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -452,18 +452,18 @@ Adds all missing imports by default.
 Use with 'prefix-arg` to select imports to add."
   (interactive)
   (when (rustic-cargo-edit-installed-p)
-    (let ((missing-imports (delete-dups
+    (if-let ((missing-imports (delete-dups
                             (seq-reduce (lambda (missing-crates errortable)
                                           (if (string= "E0432" (gethash "code" errortable))
                                               (cons (nth 3 (split-string (gethash "message" errortable) "`")) missing-crates)
                                             missing-crates))
                                         (gethash (buffer-file-name) (lsp-diagnostics t)) '()))))
-      (if missing-imports
-          (rustic-run-cargo-command (format  "cargo add %s"
-                                             (if current-prefix-arg
-                                                 (completing-read "Select import to add to Cargo.toml" missing-imports)
-                                               (mapconcat 'identity  missing-imports " "))))
-        (message "Couldn't find any imports to add. If this was a mistake, make sure your language server is running properly.")))))
+      (rustic-run-cargo-command (format  "cargo add %s"
+                                         (if current-prefix-arg
+                                             (completing-read "Select import to add to Cargo.toml" missing-imports)
+                                           (mapconcat 'identity  missing-imports " "))))
+      (message "Couldn't find any imports to add. If this was a mistake, make sure your language server is running properly."))))
+
 
 ;;;###autoload
 (defun rustic-cargo-rm (&optional arg)

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -448,22 +448,23 @@ If running with prefix command `C-u', read whole command from minibuffer."
 
 
 ;; (:code "E0432" :message "unresolved import `aosenuh`\nno `aosenuh` external crate" :range
-                   ;; (:end
-                   ;;  (:character 11 :line 0)
-                   ;;  :start
-                   ;;  (:character 4 :line 0))
-                   ;; :severity 1 :source "rustc")
-                   ;;
+;; (:end
+;;  (:character 11 :line 0)
+;;  :start
+;;  (:character 4 :line 0))
+;; :severity 1 :source "rustc")
+;;
 (defun rustic-cargo-add-missing-imports-eglot ()
   "Quiet doctor."
   (interactive)
   (seq-reduce (lambda (missing-crates clstruct)
-                (message "struct: %s" clstruct)
-                (if (string-match-p
-                     (regexp-quote "unresolved import")
-                     (format "%s" (flymake--diag-text clstruct)))
-                    (cons clstruct missing-crates)
-                  missing-crates)) eglot--unreported-diagnostics '()))
+                (when (and  (flymake--diag-p clstruct)
+                            (string-match-p
+                             (regexp-quote "unresolved import `")
+                             (format "%s" (flymake--diag-text clstruct))))
+                  (progn
+                    (message "missing crate: %s" (nth 3 (split-string (flymake--diag-text clstruct) "`"))))))
+              eglot--unreported-diagnostics '()))
 
 (defun rustic-cargo-add-missing-imports ()
   "Add missing imports to Cargo.toml.


### PR DESCRIPTION
For https://github.com/brotzeit/rustic/issues/169
Now supports both eglot and lsp. I'm not a huge fan of how I collect the missing imports from eglot. It works by inspecting errors that eglot is about to send to flymake, which makes it a bit hacky. In the lsp-mode version, a call to the function `lsp-diagnostics` just returns everything that's needed, but I could not find an equivalent function in eglot, though obviously it must be there somewhere. 

Werks on my machine, but I need to try it a bit more and have another look at the code.