### PR TITLE
Use cargo metadata to find workspace root

### DIFF
--- a/rustic-common.el
+++ b/rustic-common.el
@@ -59,9 +59,12 @@ non-nil."
   "Get the workspace root.
 If NODEFAULT is t, return nil instead of `default-directory' if directory is
 not in a rust project."
-  (let ((dir (alist-get '\workspace_root
-                        (json-read-from-string
-                         (shell-command-to-string "cargo metadata --format-version 1")))))
+  (let ((dir (or  (condition-case nil
+                      (alist-get '\workspace_root
+                                 (json-read-from-string
+                                  (shell-command-to-string "cargo metadata --format-version 1")))
+                    (error nil))
+                  default-directory)))
     (if dir
         (expand-file-name dir)
       (if nodefault

--- a/rustic-common.el
+++ b/rustic-common.el
@@ -60,7 +60,7 @@ non-nil."
 If NODEFAULT is t, return nil instead of `default-directory' if directory is
 not in a rust project."
   (let ((dir (locate-dominating-file
-              (or buffer-file-name default-directory) "Cargo.toml")))
+              (or buffer-file-name default-directory) "Cargo.lock")))
     (if dir
         (expand-file-name dir)
       (if nodefault

--- a/rustic-common.el
+++ b/rustic-common.el
@@ -54,7 +54,6 @@ non-nil."
   (or rustic-format-on-save (eq rustic-format-trigger 'on-save)))
 
 ;;; Essentials
-
 (defun rustic-buffer-workspace (&optional nodefault)
   "Get the workspace root.
 If NODEFAULT is t, return nil instead of `default-directory' if directory is
@@ -64,7 +63,7 @@ not in a rust project."
                                  (json-read-from-string
                                   (shell-command-to-string "cargo metadata --format-version 1")))
                     (error nil))
-                  default-directory)))
+                  (locate-dominating-file default-directory "Cargo.toml"))))
     (if dir
         (expand-file-name dir)
       (if nodefault

--- a/rustic-common.el
+++ b/rustic-common.el
@@ -54,6 +54,7 @@ non-nil."
   (or rustic-format-on-save (eq rustic-format-trigger 'on-save)))
 
 ;;; Essentials
+
 (defun rustic-buffer-workspace (&optional nodefault)
   "Get the workspace root.
 If NODEFAULT is t, return nil instead of `default-directory' if directory is
@@ -63,7 +64,7 @@ not in a rust project."
                                  (json-read-from-string
                                   (shell-command-to-string "cargo metadata --format-version 1")))
                     (error nil))
-                  (locate-dominating-file default-directory "Cargo.toml"))))
+                  default-directory)))
     (if dir
         (expand-file-name dir)
       (if nodefault

--- a/rustic-common.el
+++ b/rustic-common.el
@@ -60,9 +60,9 @@ non-nil."
 If NODEFAULT is t, return nil instead of `default-directory' if directory is
 not in a rust project."
   (let ((dir (or  (condition-case nil
-                      (alist-get '\workspace_root
-                                 (json-read-from-string
-                                  (shell-command-to-string "cargo metadata --format-version 1")))
+                      (concat  (alist-get '\workspace_root
+                                          (json-read-from-string
+                                           (shell-command-to-string "cargo metadata --format-version 1"))) "/")
                     (error nil))
                   default-directory)))
     (if dir

--- a/rustic-common.el
+++ b/rustic-common.el
@@ -59,12 +59,8 @@ non-nil."
   "Get the workspace root.
 If NODEFAULT is t, return nil instead of `default-directory' if directory is
 not in a rust project."
-  (let ((dir (or  (condition-case nil
-                      (concat  (alist-get '\workspace_root
-                                          (json-read-from-string
-                                           (shell-command-to-string "cargo metadata --format-version 1"))) "/")
-                    (error nil))
-                  default-directory)))
+  (let ((dir (locate-dominating-file
+              (or buffer-file-name default-directory) "Cargo.toml")))
     (if dir
         (expand-file-name dir)
       (if nodefault

--- a/rustic-common.el
+++ b/rustic-common.el
@@ -59,8 +59,9 @@ non-nil."
   "Get the workspace root.
 If NODEFAULT is t, return nil instead of `default-directory' if directory is
 not in a rust project."
-  (let ((dir (locate-dominating-file
-              (or buffer-file-name default-directory) "Cargo.toml")))
+  (let ((dir (alist-get '\workspace_root
+                        (json-read-from-string
+                         (shell-command-to-string "cargo metadata --format-version 1")))))
     (if dir
         (expand-file-name dir)
       (if nodefault


### PR DESCRIPTION
https://github.com/brotzeit/rustic/issues/174
How about this? 