### PR TITLE
Enforce 'alist for json-object-type

### DIFF
--- a/rustic-flycheck.el
+++ b/rustic-flycheck.el
@@ -54,7 +54,8 @@ targets could be found."
                                          (format "%s exited with %s." args code-or-signal))))
                    (user-error error-message)))
                (goto-char (point-min))
-               (let ((json-array-type 'list))
+               (let ((json-array-type 'list)
+                     (json-object-type 'alist))
                  (json-read))))))
         (cargo (funcall flycheck-executable-find "cargo")))
     (unless cargo


### PR DESCRIPTION
In lsp-mode, json-object-type gets let-bound to 'hash-table prior to
invoking rustic-flycheck-get-cargo-targets:
https://github.com/emacs-lsp/lsp-mode/blob/936dd86142c43e01f38d8b6aaf920b32a8ea2be4/lsp-mode.el#L6809

I noticed this when I opened a Rust file in emacs-tree-sitter. I'm using Emacs 28 native-compiled with rust-analyzer and lsp-mode. lsp-mode was compiled with `lsp-use-plists` set to `t`.

``` emacs-lisp
Error in rustic-flycheck-setup: (wrong-type-argument listp #s(hash-table size 65 test equal rehash-size 1.5 rehash-threshold 0.8125 data ("packages" (#s(hash-table size 65 test equal rehash-size 1.5 rehash-threshold 0.8125 data ("name" "emacs-tree-sitter" "version" "0.12.1" "id" "emacs-tree-sitter 0.12.1 (path+file:///home/brian/.emacs.d/straight/repos/emacs-tree-sitter/core)" "license" nil "license_file" nil "description" nil "source" nil "dependencies" (#s(hash-table size 65 test equal rehash-size 1.5 rehash-threshold 0.8125 data ("name" "emacs" "source" "registry+https://github.com/rust-lang/crates.io-index" "req" "^0.14.1" "kind" nil "rename" nil "optional" :json-false "uses_default_features" t "features" nil "target" nil "registry" nil)) #s(hash-table size 65 test equal rehash-size 1.5 rehash-threshold 0.8125 data ("name" "libloading" "source" "registry+https://github.com/rust-lang/crates.io-index" "req" "^0.6.2" "kind" nil "rename" nil "optional" :json-false "uses_default_features" t "features" nil "target" nil "registry" nil)) #s(hash-table size 65 test equal rehash-size 1.5 rehash-threshold 0.8125 data ("name" "once_cell" "source" "registry+https://github.com/rust-lang/crates.io-index" "req" "^1.2.0" "kind" nil "rename" nil "optional" :json-false "uses_default_features" t "features" nil "target" nil "registry" nil)) #s(hash-table size 65 test equal rehash-size 1.5 rehash-threshold 0.8125 data ("name" "tree-sitter" "source" "registry+https://github.com/rust-lang/crates.io-index" "req" "^0.17.1" "kind" nil "rename" nil "optional" :json-false "uses_default_features" t "features" nil "target" nil "registry" nil))) "targets" (#s(hash-table size 65 test equal rehash-size 1.5 rehash-threshold 0.8125 data ("kind" ("cdylib") "crate_types" ("cdylib") "name" "tsc_dyn" "src_path" "/home/brian/.emacs.d/straight/repos/emacs-tree-sitter/core/src/lib.rs" "edition" "2018" "doctest" :json-false "test" t))) "features" #s(hash-table size 65 test equal rehash-size 1.5 rehash-threshold 0.8125 data ()) "manifest_path" "/home/brian/.emacs.d/straight/repos/emacs-tree-sitter/core/Cargo.toml" "metadata" nil "publish" nil "authors" ("Tuấn-Anh Nguyễn <ubolonton@gmail.com>") "categories" nil "keywords" nil "readme" nil "repository" nil "edition" "2018" "links" nil))) "workspace_members" ("emacs-tree-sitter 0.12.1 (path+file:///home/brian/.emacs.d/straight/repos/emacs-tree-sitter/core)") "resolve" nil "target_directory" "/home/brian/.emacs.d/straight/repos/emacs-tree-sitter/target" "version" 1 "workspace_root" "/home/brian/.emacs.d/straight/repos/emacs-tree-sitter" "metadata" nil))) [2 times]
```

``` emacs-lisp

Debugger entered--Lisp error: (wrong-type-argument listp #<hash-table equal 7/65 0x911dc9b>)
  (rustic-flycheck-get-cargo-targets "/home/brian/.emacs.d/straight/repos/emacs-tree-sit...")
  (rustic-flycheck-find-cargo-target "/home/brian/.emacs.d/straight/repos/emacs-tree-sit...")
  (rustic-flycheck-setup)
  (flycheck-mode 1)
  (lsp-diagnostics-flycheck-enable)
  (lsp-diagnostics-mode 1)
  (lsp-diagnostics--enable)
  (#f(compiled-function () #<bytecode 0x1f5181e9266d>))
  (lsp-configure-buffer)
  (lsp-managed-mode 1)
  (lsp--text-document-did-open)
  (lsp--open-in-workspace #s(lsp--workspace :ewoc nil :server-capabilities (:callHierarchyProvider t :codeActionProvider (:codeActionKinds ["" "quickfix" "refactor" "refactor.extract" "refactor.inline" "refactor.rewrite"]) :codeLensProvider (:resolveProvider t) :completionProvider (:triggerCharacters [":" "."]) :definitionProvider t :documentFormattingProvider t :documentHighlightProvider t :documentOnTypeFormattingProvider (:firstTriggerCharacter "=" :moreTriggerCharacter ["." ">"]) :documentSymbolProvider t :experimental (:joinLines t :onEnter t :parentModule t :runnables (:kinds ["cargo"]) :ssr t) :foldingRangeProvider t :hoverProvider t :implementationProvider t :referencesProvider t :renameProvider (:prepareProvider t) :selectionRangeProvider t :semanticTokensProvider (:full (:delta t) :legend (:tokenModifiers ["documentation" "declaration" "definition" "static" "abstract" "deprecated" "readonly" "constant" "controlFlow" "injected" "mutable" "consuming" "unsafe" "attribute"] :tokenTypes ["comment" "keyword" "string" "number" "regexp" "operator" "namespace" "type" "struct" "class" "interface" "enum" "enumMember" "typeParameter" "function" "member" "property" "macro" "variable" "parameter" "attribute" "boolean" "builtinType" "escapeSequence" "formatSpecifier" "generic" "lifetime" "punctuation" "selfKeyword" "typeAlias" "union" "unresolvedReference"]) :range t) :signatureHelpProvider (:triggerCharacters ["(" ","]) :textDocumentSync (:change 2 :openClose t :save #<hash-table equal 0/65 0x9a405b3>) :typeDefinitionProvider t :workspaceSymbolProvider t) :registered-server-capabilities nil :root "/home/brian/.emacs.d/straight/repos/emacs-tree-sit..." :client #s(lsp--client :language-id nil :add-on? nil :new-connection (:connect #f(compiled-function (filter sentinel name environment-fn) #<bytecode 0x106cfb88441a36b5>) :test\? #f(compiled-function () #<bytecode 0x1c0c653cd645e8d0>)) :ignore-regexps nil :ignore-messages nil :notification-handlers #<hash-table equal 1/65 0x8ee2e71> :request-handlers #<hash-table equal 0/65 0x8ee333d> :response-handlers #<hash-table eql 1/65 0x8ee2f35> :prefix-function nil :uri-handlers #<hash-table equal 0/65 0x8ee2f55> :action-handlers #<hash-table equal 1/65 0x8ee2f15> :major-modes (rust-mode rustic-mode) :activation-fn nil :priority 1 :server-id rust-analyzer :multi-root nil :initialization-options lsp-rust-analyzer--make-init-options :custom-capabilities ((experimental (snippetTextEdit . t))) :library-folders-fn #f(compiled-function (workspace) #<bytecode 0x6222196a14fcdb6>) :before-file-open-fn nil :initialized-fn nil :remote? nil :completion-in-comments? nil :path->uri-fn nil :uri->path-fn nil :environment-fn nil :after-open-fn #f(compiled-function () #<bytecode 0x1f539bc022e9>) :async-request-handlers #<hash-table equal 0/65 0x8ee3b45> :download-server-fn #f(compiled-function (client callback error-callback update\?) #<bytecode 0x194944d239517233>) :download-in-progress? nil :buffers nil) :host-root nil :proc #<process rust-analyzer> :cmd-proc #<process rust-analyzer> :buffers (#<buffer query.rs>) :semantic-highlighting-faces nil :semantic-highlighting-modifier-faces nil :extra-client-capabilities nil :status initialized :metadata #<hash-table equal 0/65 0x9c159af> :watches #<hash-table equal 0/65 0x9c15c85> :workspace-folders nil :last-id 0 :status-string nil :shutdown-action nil :diagnostics #<hash-table equal 0/65 0x9c160f3> :work-done-tokens #<hash-table equal 0/65 0x9c163f1>))
  (#f(compiled-function (buffer) #<bytecode -0x13a43d0016a7bac8>) #<buffer query.rs>)
  (mapc #f(compiled-function (buffer) #<bytecode -0x13a43d0016a7bac8>) (#<buffer query.rs>))
  (#f(compiled-function (response) #<bytecode 0x3efd341faec2ea>) (:capabilities (:callHierarchyProvider t :codeActionProvider (:codeActionKinds ["" "quickfix" "refactor" "refactor.extract" "refactor.inline" "refactor.rewrite"]) :codeLensProvider (:resolveProvider t) :completionProvider (:triggerCharacters [":" "."]) :definitionProvider t :documentFormattingProvider t :documentHighlightProvider t :documentOnTypeFormattingProvider (:firstTriggerCharacter "=" :moreTriggerCharacter ["." ">"]) :documentSymbolProvider t :experimental (:joinLines t :onEnter t :parentModule t :runnables (:kinds ["cargo"]) :ssr t) :foldingRangeProvider t :hoverProvider t :implementationProvider t :referencesProvider t :renameProvider (:prepareProvider t) :selectionRangeProvider t :semanticTokensProvider (:full (:delta t) :legend (:tokenModifiers ["documentation" "declaration" "definition" "static" "abstract" "deprecated" "readonly" "constant" "controlFlow" "injected" "mutable" "consuming" "unsafe" "attribute"] :tokenTypes ["comment" "keyword" "string" "number" "regexp" "operator" "namespace" "type" "struct" "class" "interface" "enum" "enumMember" "typeParameter" "function" "member" "property" "macro" "variable" "parameter" "attribute" "boolean" "builtinType" "escapeSequence" "formatSpecifier" "generic" "lifetime" "punctuation" "selfKeyword" "typeAlias" "union" "unresolvedReference"]) :range t) :signatureHelpProvider (:triggerCharacters ["(" ","]) :textDocumentSync (:change 2 :openClose t :save #<hash-table equal 0/65 0x9a405b3>) :typeDefinitionProvider t :workspaceSymbolProvider t) :serverInfo (:name "rust-analyzer" :version "2020-10-19")))
  (#f(compiled-function (result) #<bytecode -0x116635295a06f842>) (:capabilities (:callHierarchyProvider t :codeActionProvider (:codeActionKinds ["" "quickfix" "refactor" "refactor.extract" "refactor.inline" "refactor.rewrite"]) :codeLensProvider (:resolveProvider t) :completionProvider (:triggerCharacters [":" "."]) :definitionProvider t :documentFormattingProvider t :documentHighlightProvider t :documentOnTypeFormattingProvider (:firstTriggerCharacter "=" :moreTriggerCharacter ["." ">"]) :documentSymbolProvider t :experimental (:joinLines t :onEnter t :parentModule t :runnables (:kinds ["cargo"]) :ssr t) :foldingRangeProvider t :hoverProvider t :implementationProvider t :referencesProvider t :renameProvider (:prepareProvider t) :selectionRangeProvider t :semanticTokensProvider (:full (:delta t) :legend (:tokenModifiers ["documentation" "declaration" "definition" "static" "abstract" "deprecated" "readonly" "constant" "controlFlow" "injected" "mutable" "consuming" "unsafe" "attribute"] :tokenTypes ["comment" "keyword" "string" "number" "regexp" "operator" "namespace" "type" "struct" "class" "interface" "enum" "enumMember" "typeParameter" "function" "member" "property" "macro" "variable" "parameter" "attribute" "boolean" "builtinType" "escapeSequence" "formatSpecifier" "generic" "lifetime" "punctuation" "selfKeyword" "typeAlias" "union" "unresolvedReference"]) :range t) :signatureHelpProvider (:triggerCharacters ["(" ","]) :textDocumentSync (:change 2 :openClose t :save #<hash-table equal 0/65 0x9a405b3>) :typeDefinitionProvider t :workspaceSymbolProvider t) :serverInfo (:name "rust-analyzer" :version "2020-10-19")))
  (#f(compiled-function (result) #<bytecode -0x6420544fba0fd91>) (:capabilities (:callHierarchyProvider t :codeActionProvider (:codeActionKinds ["" "quickfix" "refactor" "refactor.extract" "refactor.inline" "refactor.rewrite"]) :codeLensProvider (:resolveProvider t) :completionProvider (:triggerCharacters [":" "."]) :definitionProvider t :documentFormattingProvider t :documentHighlightProvider t :documentOnTypeFormattingProvider (:firstTriggerCharacter "=" :moreTriggerCharacter ["." ">"]) :documentSymbolProvider t :experimental (:joinLines t :onEnter t :parentModule t :runnables (:kinds ["cargo"]) :ssr t) :foldingRangeProvider t :hoverProvider t :implementationProvider t :referencesProvider t :renameProvider (:prepareProvider t) :selectionRangeProvider t :semanticTokensProvider (:full (:delta t) :legend (:tokenModifiers ["documentation" "declaration" "definition" "static" "abstract" "deprecated" "readonly" "constant" "controlFlow" "injected" "mutable" "consuming" "unsafe" "attribute"] :tokenTypes ["comment" "keyword" "string" "number" "regexp" "operator" "namespace" "type" "struct" "class" "interface" "enum" "enumMember" "typeParameter" "function" "member" "property" "macro" "variable" "parameter" "attribute" "boolean" "builtinType" "escapeSequence" "formatSpecifier" "generic" "lifetime" "punctuation" "selfKeyword" "typeAlias" "union" "unresolvedReference"]) :range t) :signatureHelpProvider (:triggerCharacters ["(" ","]) :textDocumentSync (:change 2 :openClose t :save #<hash-table equal 0/65 0x9a405b3>) :typeDefinitionProvider t :workspaceSymbolProvider t) :serverInfo (:name "rust-analyzer" :version "2020-10-19")))
  (lsp--parser-on-message (:jsonrpc "2.0" :id 326 :result (:capabilities (:callHierarchyProvider t :codeActionProvider (:codeActionKinds ["" "quickfix" "refactor" "refactor.extract" "refactor.inline" "refactor.rewrite"]) :codeLensProvider (:resolveProvider t) :completionProvider (:triggerCharacters [":" "."]) :definitionProvider t :documentFormattingProvider t :documentHighlightProvider t :documentOnTypeFormattingProvider (:firstTriggerCharacter "=" :moreTriggerCharacter ["." ">"]) :documentSymbolProvider t :experimental (:joinLines t :onEnter t :parentModule t :runnables (:kinds ...) :ssr t) :foldingRangeProvider t :hoverProvider t :implementationProvider t :referencesProvider t :renameProvider (:prepareProvider t) :selectionRangeProvider t :semanticTokensProvider (:full (:delta t) :legend (:tokenModifiers ... :tokenTypes ...) :range t) :signatureHelpProvider (:triggerCharacters ["(" ","]) :textDocumentSync (:change 2 :openClose t :save #<hash-table equal 0/65 0x9a405b3>) ...) :serverInfo (:name "rust-analyzer" :version "2020-10-19"))) #s(lsp--workspace :ewoc nil :server-capabilities (:callHierarchyProvider t :codeActionProvider (:codeActionKinds ["" "quickfix" "refactor" "refactor.extract" "refactor.inline" "refactor.rewrite"]) :codeLensProvider (:resolveProvider t) :completionProvider (:triggerCharacters [":" "."]) :definitionProvider t :documentFormattingProvider t :documentHighlightProvider t :documentOnTypeFormattingProvider (:firstTriggerCharacter "=" :moreTriggerCharacter ["." ">"]) :documentSymbolProvider t :experimental (:joinLines t :onEnter t :parentModule t :runnables (:kinds ["cargo"]) :ssr t) :foldingRangeProvider t :hoverProvider t :implementationProvider t :referencesProvider t :renameProvider (:prepareProvider t) :selectionRangeProvider t :semanticTokensProvider (:full (:delta t) :legend (:tokenModifiers ["documentation" "declaration" "definition" "static" "abstract" "deprecated" "readonly" "constant" "controlFlow" "injected" "mutable" "consuming" "unsafe" "attribute"] :tokenTypes ["comment" "keyword" "string" "number" "regexp" "operator" "namespace" "type" "struct" "class" "interface" "enum" "enumMember" "typeParameter" "function" "member" "property" "macro" "variable" "parameter" "attribute" "boolean" "builtinType" "escapeSequence" "formatSpecifier" "generic" "lifetime" "punctuation" "selfKeyword" "typeAlias" "union" "unresolvedReference"]) :range t) :signatureHelpProvider (:triggerCharacters ["(" ","]) :textDocumentSync (:change 2 :openClose t :save #<hash-table equal 0/65 0x9a405b3>) ...) :registered-server-capabilities nil :root "/home/brian/.emacs.d/straight/repos/em..." :client #s(lsp--client :language-id nil :add-on? nil :new-connection (:connect #f(compiled-function (filter sentinel name environment-fn) #<bytecode 0x106cfb88441a36b5>) :test\? #f(compiled-function () #<bytecode 0x1c0c653cd645e8d0>)) :ignore-regexps nil :ignore-messages nil :notification-handlers #<hash-table equal 1/65 0x8ee2e71> :request-handlers #<hash-table equal 0/65 0x8ee333d> :response-handlers #<hash-table eql 1/65 0x8ee2f35> :prefix-function nil :uri-handlers #<hash-table equal 0/65 0x8ee2f55> :action-handlers #<hash-table equal 1/65 0x8ee2f15> :major-modes (rust-mode rustic-mode) :activation-fn nil :priority 1 :server-id rust-analyzer :multi-root nil :initialization-options lsp-rust-analyzer--make-init-options :custom-capabilities ((experimental (snippetTextEdit . t))) :library-folders-fn #f(compiled-function (workspace) #<bytecode 0x6222196a14fcdb6>) :before-file-open-fn nil :initialized-fn nil :remote? nil :completion-in-comments? nil :path->uri-fn nil :uri->path-fn nil :environment-fn nil :after-open-fn #f(compiled-function () #<bytecode 0x1f539bc022e9>) :async-request-handlers #<hash-table equal 0/65 0x8ee3b45> :download-server-fn #f(compiled-function (client callback error-callback update\?) #<bytecode 0x194944d239517233>) :download-in-progress? nil :buffers nil) :host-root nil :proc #<process rust-analyzer> :cmd-proc #<process rust-analyzer> :buffers (#<buffer query.rs>) :semantic-highlighting-faces nil :semantic-highlighting-modifier-faces nil :extra-client-capabilities nil :status initialized :metadata #<hash-table equal 0/65 0x9c159af> :watches #<hash-table equal 0/65 0x9c15c85> :workspace-folders nil :last-id 0 :status-string nil :shutdown-action nil :diagnostics #<hash-table equal 0/65 0x9c160f3> :work-done-tokens #<hash-table equal 0/65 0x9c163f1>))
  (#f(compiled-function (proc input) #<bytecode -0x18968b4fbfff6475>) #<process rust-analyzer> "Content-Length: 1690\15\n\15\n{\"jsonrpc\":\"2.0\",\"id\":326,...")
  (accept-process-output #<process emacsql-sqlite> 30)
  (#f(compiled-function (connection &optional timeout) "Block until CONNECTION is waiting for further input." #<bytecode -0x155a44c32bc9e1fc>) #<forge-database forge-database-2b613f2>)
  (apply #f(compiled-function (connection &optional timeout) "Block until CONNECTION is waiting for further input." #<bytecode -0x155a44c32bc9e1fc>) #<forge-database forge-database-2b613f2> nil)
  (emacsql-wait #<forge-database forge-database-2b613f2>)
  (#f(compiled-function (connection sql &rest args) "Send SQL s-expression to CONNECTION and return the results." #<bytecode 0xaab472e966ecead>) #<forge-database forge-database-2b613f2> [:select * :from repository :where (and (= forge $s1) (= owner $s2) (= name $s3))] "github.com" "ubolonton" "emacs-tree-sitter")
  (apply #f(compiled-function (connection sql &rest args) "Send SQL s-expression to CONNECTION and return the results." #<bytecode 0xaab472e966ecead>) (#<forge-database forge-database-2b613f2> [:select * :from repository :where (and (= forge $s1) (= owner $s2) (= name $s3))] "github.com" "ubolonton" "emacs-tree-sitter"))
  (#f(compiled-function (&rest cnm-args) #<bytecode 0xe919fde1980db36>) #<forge-database forge-database-2b613f2> [:select * :from repository :where (and (= forge $s1) (= owner $s2) (= name $s3))] "github.com" "ubolonton" "emacs-tree-sitter")
  (apply #f(compiled-function (&rest cnm-args) #<bytecode 0xe919fde1980db36>) #<forge-database forge-database-2b613f2> [:select * :from repository :where (and (= forge $s1) (= owner $s2) (= name $s3))] ("github.com" "ubolonton" "emacs-tree-sitter"))
  (#f(compiled-function (connection sql &rest args) #<bytecode 0x41674e57cf634ef>) #f(compiled-function (&rest cnm-args) #<bytecode 0xe919fde1980db36>) #<forge-database forge-database-2b613f2> [:select * :from repository :where (and (= forge $s1) (= owner $s2) (= name $s3))] "github.com" "ubolonton" "emacs-tree-sitter")
  (apply #f(compiled-function (connection sql &rest args) #<bytecode 0x41674e57cf634ef>) #f(compiled-function (&rest cnm-args) #<bytecode 0xe919fde1980db36>) (#<forge-database forge-database-2b613f2> [:select * :from repository :where (and (= forge $s1) (= owner $s2) (= name $s3))] "github.com" "ubolonton" "emacs-tree-sitter"))
  (#f(compiled-function (&rest args) #<bytecode -0xabaf3fea8a23c3a>) #<forge-database forge-database-2b613f2> [:select * :from repository :where (and (= forge $s1) (= owner $s2) (= name $s3))] "github.com" "ubolonton" "emacs-tree-sitter")
  (apply #f(compiled-function (&rest args) #<bytecode -0xabaf3fea8a23c3a>) #<forge-database forge-database-2b613f2> ([:select * :from repository :where (and (= forge $s1) (= owner $s2) (= name $s3))] "github.com" "ubolonton" "emacs-tree-sitter"))
  (emacsql #<forge-database forge-database-2b613f2> [:select * :from repository :where (and (= forge $s1) (= owner $s2) (= name $s3))] "github.com" "ubolonton" "emacs-tree-sitter")
  (forge-sql [:select * :from repository :where (and (= forge $s1) (= owner $s2) (= name $s3))] "github.com" "ubolonton" "emacs-tree-sitter")
  (#f(compiled-function (&rest rest) "((host owner name) &optional remote demand)\n\nReturn the repository identified by HOST, OWNER and NAME." #<bytecode -0x198cc8f271103dc8>) ("github.com" "ubolonton" "emacs-tree-sitter") "origin" full)
  (apply #f(compiled-function (&rest rest) "((host owner name) &optional remote demand)\n\nReturn the repository identified by HOST, OWNER and NAME." #<bytecode -0x198cc8f271103dc8>) ("github.com" "ubolonton" "emacs-tree-sitter") ("origin" full))
  (#f(compiled-function (arg &rest args) #<bytecode -0xa8d5b81421a08eb>) ("github.com" "ubolonton" "emacs-tree-sitter") "origin" full)
  (apply #f(compiled-function (arg &rest args) #<bytecode -0xa8d5b81421a08eb>) (("github.com" "ubolonton" "emacs-tree-sitter") "origin" full))
  (forge-get-repository ("github.com" "ubolonton" "emacs-tree-sitter") "origin" full)
  (#f(compiled-function (url &optional remote demand) "Return the repository at URL." #<bytecode -0x1c47360ea4a49c34>) "https://github.com/ubolonton/emacs-tree-sitter.git" "origin" full)
  (apply #f(compiled-function (url &optional remote demand) "Return the repository at URL." #<bytecode -0x1c47360ea4a49c34>) "https://github.com/ubolonton/emacs-tree-sitter.git" ("origin" full))
  (#f(compiled-function (arg &rest args) #<bytecode -0xa8d5b81421a08eb>) "https://github.com/ubolonton/emacs-tree-sitter.git" "origin" full)
  (apply #f(compiled-function (arg &rest args) #<bytecode -0xa8d5b81421a08eb>) ("https://github.com/ubolonton/emacs-tree-sitter.git" "origin" full))
  (forge-get-repository "https://github.com/ubolonton/emacs-tree-sitter.git" "origin" full)
  (#f(compiled-function (demand &optional remote) "Return the current forge repository.\n\nIf the `forge-buffer-repository' is non-nil, then return that.\nOtherwise if `forge-buffer-topic' is non-nil, then return the\nrepository for that.  Finally if both variables are nil, then\nreturn the forge repository corresponding to the current Git\nrepository, if any." #<bytecode -0x1cc04f88a1ab07ee>) full)
  (apply #f(compiled-function (demand &optional remote) "Return the current forge repository.\n\nIf the `forge-buffer-repository' is non-nil, then return that.\nOtherwise if `forge-buffer-topic' is non-nil, then return the\nrepository for that.  Finally if both variables are nil, then\nreturn the forge repository corresponding to the current Git\nrepository, if any." #<bytecode -0x1cc04f88a1ab07ee>) full nil)
  (#f(compiled-function (arg &rest args) #<bytecode -0xa8d5b81421a08eb>) full)
  (apply #f(compiled-function (arg &rest args) #<bytecode -0xa8d5b81421a08eb>) full)
  (forge-get-repository full)
  (forge-bug-reference-setup)
  (run-hooks change-major-mode-after-body-hook prog-mode-hook rustic-mode-hook)
  (apply run-hooks (change-major-mode-after-body-hook prog-mode-hook rustic-mode-hook))
  (run-mode-hooks rustic-mode-hook)
  (rustic-mode)
  (set-auto-mode-0 rustic-mode nil)
  (#<subr set-auto-mode>)
  (so-long--set-auto-mode #<subr set-auto-mode>)
  (apply so-long--set-auto-mode #<subr set-auto-mode> nil)
  (set-auto-mode)
  (normal-mode t)
  (after-find-file nil t)
  (find-file-noselect-1 #<buffer query.rs> "~/.emacs.d/straight/repos/emacs-tree-sitter/core/s..." nil nil "~/.emacs.d/straight/repos/emacs-tree-sitter/core/s..." (1446010 2049))
  (find-file-noselect "/home/brian/.emacs.d/straight/repos/emacs-tree-sit..." nil nil nil)
  (find-file "/home/brian/.emacs.d/straight/repos/emacs-tree-sit...")
  (dired-find-file)
  (dired-open-file nil)
  (funcall-interactively dired-open-file nil)
  (command-execute dired-open-file)
```