### PR TITLE
Add async as a dependency

### DIFF
--- a/Cask
+++ b/Cask
@@ -4,6 +4,7 @@
 (package-file "rustic.el")
 
 (development
+ (depends-on "async")
  (depends-on "ert-runner")
  (depends-on "lsp-mode")
  (depends-on "flycheck")

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ ELCS  = $(ELS:.el=.elc)
 ## Without Cask
 ifdef WITHOUT_CASK
 
+DEPS  = async
 DEPS  = dash
 DEPS += f
 DEPS += flycheck

--- a/rustic-doc.el
+++ b/rustic-doc.el
@@ -18,14 +18,14 @@
 (require 'f)
 (require 'async)
 
-(if (< emacs-major-version 27)
-    (defun rustic-doc--xdg-data-home ()
-      (or (getenv "XDG_DATA_HOME")
-          (concat (file-name-as-directory (getenv "HOME"))
-                  ".local/share")))
-  (progn
+(eval-and-compile
+  (if (< emacs-major-version 27)
+      (defun rustic-doc--xdg-data-home ()
+        (or (getenv "XDG_DATA_HOME")
+            (concat (file-name-as-directory (getenv "HOME"))
+                    ".local/share")))
     (require 'xdg)
-    (fset 'rustic-doc--xdg-data-home 'xdg-data-home)))
+    (fset 'rustic-doc--xdg-data-home #'xdg-data-home)))
 
 (defvar rustic-doc-lua-filter (concat (file-name-as-directory (getenv "HOME"))
                                       ".local/bin/rustic-doc-filter.lua")

--- a/rustic-doc.el
+++ b/rustic-doc.el
@@ -16,6 +16,7 @@
 (require 'url)
 (require 'lsp-mode)
 (require 'f)
+(require 'async)
 
 (if (< emacs-major-version 27)
     (defun rustic-doc--xdg-data-home ()

--- a/rustic.el
+++ b/rustic.el
@@ -4,7 +4,7 @@
 ;; Author: Mozilla
 ;;
 ;; Keywords: languages
-;; Package-Requires: ((emacs "26.1") (xterm-color "1.6") (dash "2.13.0") (s "1.10.0") (f "0.18.2") (projectile "0.14.0") (markdown-mode "2.3") (spinner "1.7.3") (let-alist "1.0.4") (seq "2.3") (ht "2.0"))
+;; Package-Requires: ((emacs "26.1") (xterm-color "1.6") (dash "2.13.0") (s "1.10.0") (f "0.18.2") (projectile "0.14.0") (markdown-mode "2.3") (spinner "1.7.3") (let-alist "1.0.4") (seq "2.3") (ht "2.0") (async "1.9.4"))
 
 ;; This file is distributed under the terms of both the MIT license and the
 ;; Apache License (version 2.0).


### PR DESCRIPTION
`async` is used by `rustic-doc.el`.

Also silence a separate byte-compiler warning.