### PR TITLE
No longer depend on async and projectile

### DIFF
--- a/rustic-compile.el
+++ b/rustic-compile.el
@@ -10,9 +10,9 @@
 ;;; Code:
 
 (require 'xterm-color)
-(require 'projectile)
 (require 'markdown-mode)
 
+(require 'cl-lib)
 (require 'dash)
 (require 'subr-x)
 
@@ -346,9 +346,11 @@ If NO-ERROR is t, don't throw error if user chooses not to kill running process.
 
 The variable `buffer-save-without-query' can be used for customization and
 buffers are formatted after saving if turned on by `rustic-format-trigger'."
-  (let ((buffers (condition-case ()
-                     (projectile-buffers-with-file (projectile-project-buffers))
-                   (buffer-list)))
+  (let ((buffers (cl-remove-if-not
+                  #'buffer-file-name
+                  (if (fboundp rustic-list-project-buffers-function)
+                      (funcall rustic-list-project-buffers-function)
+                    (buffer-list))))
         (b (get-buffer rustic-format-buffer-name)))
     (when (buffer-live-p b)
       (kill-buffer b))

--- a/rustic-doc.el
+++ b/rustic-doc.el
@@ -16,7 +16,6 @@
 (require 'url)
 (require 'lsp-mode)
 (require 'f)
-(require 'async)
 
 (eval-and-compile
   (if (< emacs-major-version 27)
@@ -243,11 +242,11 @@ If the user has not visited a project, returns the main doc directory."
                                 (message (format "Finished converting docs for %s"
                                                  rustic-doc-current-project)))))
             (rustic-doc-create-project-dir)
-            (async-start-process "rustic-doc-convert"
-                                 rustic-doc-convert-prog
-                                 finish-func
-                                 docs-src
-                                 (rustic-doc--project-doc-dest)))))
+            (rustic-doc--start-process "rustic-doc-convert"
+                                       rustic-doc-convert-prog
+                                       finish-func
+                                       docs-src
+                                       (rustic-doc--project-doc-dest)))))
     (message "Could not find project to convert. Visit a rust project first! (Or activate rustic-doc-mode if you are in one)")))
 
 (defun rustic-doc-install-deps ()
@@ -259,11 +258,11 @@ If the user has not visited a project, returns the main doc directory."
           (missing-makedocs (not (executable-find "cargo-makedocs"))))
       (when (and  (or missing-fd missing-makedocs missing-rg) (y-or-n-p "Missing some dependencies for rustic doc, install them? "))
         (when missing-fd
-          (async-start-process "install-fd" "cargo" nil "install" "fd-find"))
+          (rustic-doc--start-process "install-fd" "cargo" nil "install" "fd-find"))
         (when missing-rg
-          (async-start-process "install-rg" "cargo" nil "install" "ripgrep"))
+          (rustic-doc--start-process "install-rg" "cargo" nil "install" "ripgrep"))
         (when missing-makedocs
-          (async-start-process "install-makedocs" "cargo" nil "install" "cargo-makedocs"))))))
+          (rustic-doc--start-process "install-makedocs" "cargo" nil "install" "cargo-makedocs"))))))
 
 
 ;;;###autoload
@@ -275,11 +274,23 @@ If the user has not visited a project, returns the main doc directory."
   (message "Setup is converting the standard library")
   (delete-directory (concat rustic-doc-save-loc "/std")
                     t)
-  (async-start-process "*rustic-doc-std-conversion*"
-                       rustic-doc-convert-prog
-                       (lambda (_p)
-                         (message "Finished converting docs for std"))
-                       "std"))
+  (rustic-doc--start-process "*rustic-doc-std-conversion*"
+                             rustic-doc-convert-prog
+                             (lambda (_p)
+                               (message "Finished converting docs for std"))
+                             "std"))
+
+(defun rustic-doc--start-process (name program finish-func &rest program-args)
+  (let* ((buf (generate-new-buffer (concat "*" name "*")))
+         (proc (let ((process-connection-type nil))
+                 (apply #'start-process name buf program program-args))))
+    (set-process-sentinel
+     proc (or finish-func
+              (lambda (proc)
+                (let ((buf (process-buffer proc)))
+                  (when (buffer-live-p buf)
+                    (kill-buffer buf))))))
+    proc))
 
 (defun rustic-doc--thing-at-point ()
   "Return info about `thing-at-point'. If `thing-at-point' is nil, return defaults."

--- a/rustic-doc.el
+++ b/rustic-doc.el
@@ -285,11 +285,12 @@ If the user has not visited a project, returns the main doc directory."
          (proc (let ((process-connection-type nil))
                  (apply #'start-process name buf program program-args))))
     (set-process-sentinel
-     proc (or finish-func
-              (lambda (proc)
-                (let ((buf (process-buffer proc)))
-                  (when (buffer-live-p buf)
-                    (kill-buffer buf))))))
+     proc (lambda (proc)
+            (let ((buf (process-buffer proc)))
+              (when finish-func
+                (funcall finish-func proc))
+              (when (buffer-live-p buf)
+                (kill-buffer buf)))))
     proc))
 
 (defun rustic-doc--thing-at-point ()

--- a/rustic.el
+++ b/rustic.el
@@ -4,7 +4,7 @@
 ;; Author: Mozilla
 ;;
 ;; Keywords: languages
-;; Package-Requires: ((emacs "26.1") (xterm-color "1.6") (dash "2.13.0") (s "1.10.0") (f "0.18.2") (markdown-mode "2.3") (spinner "1.7.3") (let-alist "1.0.4") (seq "2.3") (ht "2.0") (async "1.9.4"))
+;; Package-Requires: ((emacs "26.1") (xterm-color "1.6") (dash "2.13.0") (s "1.10.0") (f "0.18.2") (markdown-mode "2.3") (spinner "1.7.3") (let-alist "1.0.4") (seq "2.3") (ht "2.0"))
 
 ;; This file is distributed under the terms of both the MIT license and the
 ;; Apache License (version 2.0).

--- a/rustic.el
+++ b/rustic.el
@@ -4,7 +4,7 @@
 ;; Author: Mozilla
 ;;
 ;; Keywords: languages
-;; Package-Requires: ((emacs "26.1") (xterm-color "1.6") (dash "2.13.0") (s "1.10.0") (f "0.18.2") (projectile "0.14.0") (markdown-mode "2.3") (spinner "1.7.3") (let-alist "1.0.4") (seq "2.3") (ht "2.0") (async "1.9.4"))
+;; Package-Requires: ((emacs "26.1") (xterm-color "1.6") (dash "2.13.0") (s "1.10.0") (f "0.18.2") (markdown-mode "2.3") (spinner "1.7.3") (let-alist "1.0.4") (seq "2.3") (ht "2.0") (async "1.9.4"))
 
 ;; This file is distributed under the terms of both the MIT license and the
 ;; Apache License (version 2.0).


### PR DESCRIPTION
Don't depend on `async` because doing so is completely unnecessary and don't depend on `projectile` because it should not be forced on users for the sake of some minor functionality (which we can also have without using `project` instead).