### PR TITLE
fix issue #102 (setq next-error-last-buffer buf) in rustic-compilation.

### DIFF
--- a/rustic-compile.el
+++ b/rustic-compile.el
@@ -255,6 +255,7 @@ is set to 'on-compile. If rustfmt fails, don't start compilation."
         (directory (or (plist-get args :directory) (rustic-buffer-workspace)))
         (sentinel (or (plist-get args :sentinel) #'compilation-sentinel)))
     (rustic-compilation-setup-buffer buf directory mode)
+    (setq next-error-last-buffer buf)
     (unless (plist-get args :no-display)
       (funcall rustic-compile-display-method buf))
     (with-current-buffer buf


### PR DESCRIPTION
This PR adds (setq next-error-last-buffer buf) e.g. in rustic-compilation as described by @birkenfeld in issue #102.

In my limited testing, this does seems to enable next-error to iterate through errors in the rustic-compilation buffer.