### PR TITLE
Fix indentation of chained methods

### DIFF
--- a/rustic-interaction.el
+++ b/rustic-interaction.el
@@ -102,7 +102,8 @@
                 (- (current-column) rustic-indent-offset)))))
         (cond
          ;; foo.bar(...)
-         ((rustic-looking-back-str ")")
+         ((or (rustic-looking-back-str ")")
+             (rustic-looking-back-str "?"))
           (backward-list 1)
           (funcall skip-dot-identifier))
 

--- a/rustic-interaction.el
+++ b/rustic-interaction.el
@@ -103,7 +103,7 @@
         (cond
          ;; foo.bar(...)
          ((or (rustic-looking-back-str ")")
-             (rustic-looking-back-str "?"))
+              (rustic-looking-back-str "?"))
           (backward-list 1)
           (funcall skip-dot-identifier))
 


### PR DESCRIPTION
 Method calls after `?` operators should be indented too.

This is a trivial fix, and I didn't go looking for a better way than just adding a second call to `rustic-looking-back-str`. I'll be just as happy if you just treat this as a bug report :)