### PR TITLE
Use generic function project-roots to retrieve the roots instead of calling cdr directly

### DIFF
--- a/rustic-util.el
+++ b/rustic-util.el
@@ -247,7 +247,9 @@ This is basically a wrapper around `project--buffer-list'."
     (if (fboundp 'project--buffer-list)
         (project--buffer-list pr)
       ;; Like the above function but releases before Emacs 28.
-      (let ((root (car (project-roots pr)))
+      (let ((root (if (>= 28 emacs-major-version)
+                      (project-root pr)
+                    (car (project-roots pr))))
             bufs)
         (dolist (buf (buffer-list))
           (let ((filename (or (buffer-file-name buf)

--- a/rustic-util.el
+++ b/rustic-util.el
@@ -247,7 +247,7 @@ This is basically a wrapper around `project--buffer-list'."
     (if (fboundp 'project--buffer-list)
         (project--buffer-list pr)
       ;; Like the above function but releases before Emacs 28.
-      (let ((root (cdr pr))
+      (let ((root (car (project-roots pr)))
             bufs)
         (dolist (buf (buffer-list))
           (let ((filename (or (buffer-file-name buf)

--- a/rustic-util.el
+++ b/rustic-util.el
@@ -247,9 +247,7 @@ This is basically a wrapper around `project--buffer-list'."
     (if (fboundp 'project--buffer-list)
         (project--buffer-list pr)
       ;; Like the above function but releases before Emacs 28.
-      (let ((root (if (>= 28 emacs-major-version)
-                      (project-root pr)
-                    (car (project-roots pr))))
+      (let ((root (car (project-roots pr)))
             bufs)
         (dolist (buf (buffer-list))
           (let ((filename (or (buffer-file-name buf)


### PR DESCRIPTION
Use generic function project-roots to retrieve the roots instead of calling cdr directly

Some setups add a custom function to project-find-functions, so the generic function project-roots should be used instead of directly calling cdr on the result of project-current.