### PR TITLE
Cask ministrations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,20 @@ jobs:
               with:
                   version: ${{ matrix.emacs-version }}
 
+            - uses: actions/cache@v2
+              id: cache-cask-packages
+              with:
+                path: .cask
+                key: cache-cask-packages-000
+
+            - uses: actions/cache@v2
+              id: cache-cask-executable
+              with:
+                path: ~/.cask
+                key: cache-cask-executable-000
+
             - uses: conao3/setup-cask@master
+              if: steps.cache-cask-executable.outputs.cache-hit != 'true'
               with:
                   version: snapshot
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
 
             - uses: conao3/setup-cask@master
               with:
-                  version: 0.8.4
+                  version: snapshot
 
             - name: Install requirements
               run: |
@@ -40,16 +40,6 @@ jobs:
                   source $HOME/.cargo/env
                   rustup component add rustfmt-preview
 
-            - name: Prepare Cask
-              run: |
-                  mkdir -p $HOME/.emacs.d/elpa/gnupg || true
-                  chmod 700 $HOME/.emacs.d/elpa/gnupg
-                  gpg2 --keyserver hkp://pool.sks-keyservers.net:80 --homedir $HOME/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40 || true
-                  mkdir -p $(cask package-directory) || true
-                  rsync -azSH $HOME/.emacs.d/elpa/gnupg $(cask package-directory)
-                  cask build
-                  cask install
-
             - name: Run tests
               run: |
-                cask exec ert-runner
+                make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,8 +39,8 @@ jobs:
 
             - name: Install requirements
               run: |
-                  # Configure $PATH: Executables are installed to $HOME/bin
-                  export PATH="$HOME/bin:$PATH"
+                  echo "$HOME/.cask/bin" >> $GITHUB_PATH
+                  echo "$HOME/bin" >> $GITHUB_PATH
 
                   sudo apt update
                   sudo apt install -y gnutls-bin gnupg2 dirmngr

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
               id: cache-cask-executable
               with:
                 path: ~/.cask
-                key: cache-cask-executable-000
+                key: cache-cask-executable-001
 
             - uses: conao3/setup-cask@master
               if: steps.cache-cask-executable.outputs.cache-hit != 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.elc
 /.cask
 /config.mk
+*autoloads.el

--- a/Cask
+++ b/Cask
@@ -8,4 +8,5 @@
  (depends-on "ert-runner")
  (depends-on "lsp-mode")
  (depends-on "flycheck")
- (depends-on "f"))
+ (depends-on "f")
+ (depends-on "project" "0.3.0"))

--- a/Cask
+++ b/Cask
@@ -8,5 +8,4 @@
  (depends-on "ert-runner")
  (depends-on "lsp-mode")
  (depends-on "flycheck")
- (depends-on "f")
- (depends-on "project" "0.3.0"))
+ (depends-on "f"))

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ $(CASK_DIR): Cask
 
 cask-install: $(CASK_DIR)
 
-cask-build: cask-install loaddefs
+cask-build: loaddefs
 	EMACS=$(EMACS) cask build
 
 LOAD_PATH  += -L $(subst :, -L ,$(shell cask load-path))

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ clean:
 	@rm -rf $(CLEAN)
 
 test: lisp
-	if [ -f "$(HOME)/.cargo/env" ] ; then source "$(HOME)/.cargo/env" ; fi ; \
+	if [ -f "$(HOME)/.cargo/env" ] ; then . "$(HOME)/.cargo/env" ; fi ; \
 	EMACS=$(EMACS) cask exec ert-runner
 
 loaddefs: $(PKG)-autoloads.el

--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,11 @@ else
 
 CASK_DIR := $(shell EMACS=$(EMACS) cask package-directory)
 
-cask-install: $(CASK_DIR) Cask
+$(CASK_DIR): Cask
 	EMACS=$(EMACS) cask install
 	touch $(CASK_DIR)
+
+cask-install: $(CASK_DIR)
 
 cask-build: cask-install loaddefs
 	EMACS=$(EMACS) cask build

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,13 @@ lisp: $(ELCS) loaddefs
 ## With Cask
 else
 
-cask-install:
+CASK_DIR := $(shell EMACS=$(EMACS) cask package-directory)
+
+$(CASK_DIR): Cask
+	$(CASK) install
+	touch $(CASK_DIR)
+
+cask-install: $(CASK_DIR)
 	EMACS=$(EMACS) cask install
 
 cask-build: cask-install loaddefs
@@ -99,4 +105,3 @@ $(PKG)-autoloads.el: $(ELS)
 	(setq generated-autoload-file (expand-file-name \"$@\"))\
 	(setq find-file-visit-truename t)\
 	(update-directory-autoloads default-directory))"
-

--- a/Makefile
+++ b/Makefile
@@ -44,12 +44,9 @@ else
 
 CASK_DIR := $(shell EMACS=$(EMACS) cask package-directory)
 
-$(CASK_DIR): Cask
-	$(CASK) install
-	touch $(CASK_DIR)
-
-cask-install: $(CASK_DIR)
+cask-install: $(CASK_DIR) Cask
 	EMACS=$(EMACS) cask install
+	touch $(CASK_DIR)
 
 cask-build: cask-install loaddefs
 	EMACS=$(EMACS) cask build

--- a/rustic-util.el
+++ b/rustic-util.el
@@ -247,7 +247,7 @@ This is basically a wrapper around `project--buffer-list'."
     (if (fboundp 'project--buffer-list)
         (project--buffer-list pr)
       ;; Like the above function but releases before Emacs 28.
-      (let ((root (car (project-roots pr)))
+      (let ((root (project-root pr))
             bufs)
         (dolist (buf (buffer-list))
           (let ((filename (or (buffer-file-name buf)

--- a/rustic.el
+++ b/rustic.el
@@ -4,7 +4,7 @@
 ;; Author: Mozilla
 ;;
 ;; Keywords: languages
-;; Package-Requires: ((emacs "26.1") (xterm-color "1.6") (dash "2.13.0") (s "1.10.0") (f "0.18.2") (markdown-mode "2.3") (spinner "1.7.3") (let-alist "1.0.4") (seq "2.3") (ht "2.0"))
+;; Package-Requires: ((emacs "26.1") (xterm-color "1.6") (dash "2.13.0") (s "1.10.0") (f "0.18.2") (markdown-mode "2.3") (spinner "1.7.3") (let-alist "1.0.4") (seq "2.3") (ht "2.0") (project "0.3.0"))
 
 ;; This file is distributed under the terms of both the MIT license and the
 ;; Apache License (version 2.0).


### PR DESCRIPTION
I have observed sporadic `Missing dependency: "https://elpa.gnu.org/packages/spinner-1.7.3.el: Bad Request"`.  The added github action caching should hopefully cut down on elpa networking vagaries.