### PR TITLE
use project-roots instead of project-root (fixes #256)

### DIFF
--- a/rustic-rustfmt.el
+++ b/rustic-rustfmt.el
@@ -8,7 +8,7 @@
 
 (require 'rustic-cargo)
 
-(declare-function project-root "project")
+(declare-function project-roots "project")
 
 ;;; Options
 
@@ -226,7 +226,7 @@ This is basically a wrapper around `project--buffer-list'."
     (if (fboundp 'project--buffer-list)
         (project--buffer-list pr)
       ;; Like the above function but for releases before Emacs 28.
-      (let ((root (project-root pr))
+      (let ((root (car (project-roots pr)))
             bufs)
         (dolist (buf (buffer-list))
           (let ((filename (or (buffer-file-name buf)


### PR DESCRIPTION
`project-root` is obsolete and does not exist in some versions ofEmacs*. However it is the same as just `(car (project-roots ..))` so the fix is simple.

* My build: `GNU Emacs 27.2 (build 1, x86_64-pc-linux-gnu, GTK+ Version 3.24.27, cairo version 1.17.4) of 2021-03-26`