### PR TITLE
Use rustic-analyzer-command

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ the value of `lsp-rust-server`.
 Change rust-analyzer path.
 
 ``` emacs-lisp
-(setq lsp-rust-analyzer-server-command '("~/.cargo/bin/rust-analyzer"))
+(setq rustic-analyzer-command '("~/.cargo/bin/rust-analyzer"))
 ```
 
 ### Client


### PR DESCRIPTION
To fix issue #259, I suppose rust-analyzer's path should be to set to rustic-analyzer-command instead of lsp-rust-analyzer-server-command.