### PR TITLE
Run any shell command for current project

### DIFF
--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -428,6 +428,15 @@ If BIN is not nil, create a binary application, otherwise a library."
   (interactive)
   (rustic-run-cargo-command "cargo build"))
 
+;;;###autolod
+(defun rustic-run-shell-command (&optional arg)
+  "Run an arbitrary shell command for the current project.
+Example: use it to provide an environment variable to your application like this `evn MYVAR=1 cargo run' so that it can read it at the runtime.
+As a byproduct you can run any shell command in you project like `pwd'"
+  (interactive "P")
+  (setq command (read-from-minibuffer "Command to execute: " (car compile-history) nil nil 'compile-history))
+  (rustic-run-cargo-command command (list :mode 'rustic-cargo-run-mode)))
+
 ;;;###autoload
 (defun rustic-cargo-run (&optional arg)
   "Run 'cargo run' for the current project.

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -428,11 +428,11 @@ If BIN is not nil, create a binary application, otherwise a library."
   (interactive)
   (rustic-run-cargo-command "cargo build"))
 
-;;;###autolod
+;;;###autoload
 (defun rustic-run-shell-command (&optional arg)
   "Run an arbitrary shell command for the current project.
-Example: use it to provide an environment variable to your application like this `evn MYVAR=1 cargo run' so that it can read it at the runtime.
-As a byproduct you can run any shell command in you project like `pwd'"
+Example: use it to provide an environment variable to your application like this `env MYVAR=1 cargo run' so that it can read it at the runtime.
+As a byproduct, you can run any shell command in your project like `pwd'"
   (interactive "P")
   (setq command (read-from-minibuffer "Command to execute: " (car compile-history) nil nil 'compile-history))
   (rustic-run-cargo-command command (list :mode 'rustic-cargo-run-mode)))


### PR DESCRIPTION
When learning RUST and making exercises I found that you can provide an `env` variable only then invoking `rustic-cargo-run` with an argument like `C-u`. It also didn't save the command to history. Basically, invoking `rustic-cargo-run` with an argument allows you to run any arbitrary command.

I just added a function to make running an arbitrary command explicitly and have history memorization. It's very helpful to edit the command if there has been a typo. It should also simplify assigning it a key binding. 

![image](https://user-images.githubusercontent.com/10460752/128155205-9aae05ba-90ea-4732-bd1e-0a666ad3be83.png)
