### PR TITLE
ob-rustic : run code snippets with no main()

### DIFF
--- a/rustic-babel.el
+++ b/rustic-babel.el
@@ -266,7 +266,7 @@ kill the running process."
              (dir (setq rustic-babel-dir (expand-file-name project)))
              (wrapped-body (if (string-match-p "fn main()" body)
                                body
-							 (concat "fn main() {\n" body "\n}")))
+                             (concat "fn main() {\n" body "\n}")))
              (main (expand-file-name "main.rs" (concat dir "/src"))))
         (make-directory (file-name-directory main) t)
         (rustic-babel-cargo-toml dir params)


### PR DESCRIPTION
Hi there,
this wraps the code block with `main()`
eg: ` fn main(){<body>}` when there's none,
like rust-mode does, allowing more concise snippets.
p.s: the main function detection should be made more robust: by searching for it after rust-fmt
