### PR TITLE
Made cargo-run-current-test choose closest of mod or fn to run.

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ arguments in `rustic-test-arguments`
 `rustic-cargo-test-rerun` rerun 'cargo test' with arguments stored in
 `rustic-test-arguments`
 
-`rustic-cargo-current-test` run test at point
+`rustic-cargo-current-test` run test at point, whether it's a function or a module
 
 ![](https://raw.githubusercontent.com/brotzeit/rustic/master/img/cargo_current_test.png)
 

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -171,17 +171,15 @@ When calling this function from `rustic-popup-mode', always use the value of
   (save-excursion
     (progn
       (goto-char (line-end-position))
-      (let ((location (search-backward-regexp rustic-cargo-mod-regexp nil t)))
-        (when location
-          (cons location (match-string 1)))))))
+      (when-let ((location (search-backward-regexp rustic-cargo-mod-regexp nil t)))
+        (cons location (match-string 1))))))
 
 (defun rustic-cargo--get-current-line-fn-name()
   "Return cons with location and fn name from the current line or nil."
   (save-excursion
     (goto-char (line-beginning-position))
-    (let ((location (search-forward-regexp rustic-cargo-fn-regexp (line-end-position) t)))
-      (when location
-        (cons location (match-string 1))))))
+    (when-let ((location (search-forward-regexp rustic-cargo-fn-regexp (line-end-position) t)))
+      (cons location (match-string 1)))))
 
 (defun rustic-cargo--get-current-fn-name()
   "Return fn name around point or nil."


### PR DESCRIPTION
Previously, this function would always pick the previous fn to run,
even when the current point was a module or inside a module. The
function could be from a previous module, which didn't make sense.
Running all tests in a module is a common thing to do.
This change allows users to do that.
If they are within a fn, the fn only is run.
If they are not within a fn but there's a surrounding mod, then the
whole mod is run.