### PR TITLE
Babel: Local dependency support via `:paths`

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,7 +431,6 @@ If specific crate features are required then these can be specified
 with the `:features` argument. Note that if it is just a single feature
 then a string, instead of a list, will also be accepted:
 
-
 ```
 #+BEGIN_SRC rust :crates '((tokio . 1.0)) :features '((tokio . ("rt-multi-thread" "time")))
   extern crate tokio;
@@ -442,6 +441,18 @@ then a string, instead of a list, will also be accepted:
           .block_on(async {
               tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
           });
+  }
+#+END_SRC
+```
+
+Similarly, to depend on local Rust crates, you can set the `:paths` argument:
+
+```
+#+BEGIN_SRC rust :crates '((foo . 1.0)) :paths '((foo . "/home/you/code/foo"))
+  use foo::Foo;
+
+  fn main() {
+    // Your code.
   }
 #+END_SRC
 ```

--- a/rustic-babel.el
+++ b/rustic-babel.el
@@ -208,30 +208,33 @@ Otherwise create it with `rustic-babel-generate-project'."
           (put-text-property beg end 'project (make-symbol new))
           new)))))
 
-(defun crate-dependencies (name version features)
+(defun crate-dependencies (name version features path)
   "Generate a Cargo.toml [dependencies] entry for a crate given a version and features."
-  (let ((version-string (concat "version = \"" version "\""))
-        (features-string
-         (if features
-             (concat "features = [" (mapconcat (lambda (s) (concat "\"" s "\"")) features ", ") "]")
-           nil)))
-    (let ((toml-entry (string-join (remove nil (list version-string features-string)) ", ")))
-      (concat name " = {" toml-entry "}"))))
+  (let* ((version-string (concat "version = \"" version "\""))
+         (features-string
+          (when features
+            (concat "features = [" (mapconcat (lambda (s) (concat "\"" s "\"")) features ", ") "]")))
+         (path-string
+          (when path
+            (concat "path = \"" path "\"")))
+         (toml-entry (string-join (remove nil (list version-string features-string path-string)) ", ")))
+    (concat name " = {" toml-entry "}")))
 
-(defun cargo-toml-dependencies (crate-versions crate-features)
+(defun cargo-toml-dependencies (crate-versions crate-features crate-paths)
   "Generate the [dependencies] section of a Cargo.toml file given crates and their versions & features."
   (let ((dependencies ""))
     (dolist (crate-and-version crate-versions)
-      (let ((name (car crate-and-version))
-            (version (cdr crate-and-version)))
-        (let ((features (cdr (assoc name crate-features))))
-          (setq name (symbol-name name))
-          (when (numberp version)
-            (setq version (number-to-string version)))
-          (when (not (listp features))
-            (setq features (list features)))
-          (let ((cargo-toml-entry (crate-dependencies name version features)))
-            (setq dependencies (concat dependencies cargo-toml-entry "\n"))))))
+      (let* ((name (car crate-and-version))
+             (version (cdr crate-and-version))
+             (features (cdr (assoc name crate-features)))
+             (path (cdr (assoc name crate-paths))))
+        (setq name (symbol-name name))
+        (when (numberp version)
+          (setq version (number-to-string version)))
+        (when (not (listp features))
+          (setq features (list features)))
+        (let ((cargo-toml-entry (crate-dependencies name version features path)))
+          (setq dependencies (concat dependencies cargo-toml-entry "\n")))))
     (setq dependencies (concat "[dependencies]\n" dependencies))))
 
 (defun rustic-babel-cargo-toml (dir params)
@@ -240,8 +243,9 @@ Use org-babel parameter crates from PARAMS and add them to the project in
 directory DIR."
   (let ((crates (cdr (assq :crates params)))
         (features (cdr (assq :features params)))
+        (paths (cdr (assq :paths params)))
         (toml (expand-file-name "Cargo.toml" dir)))
-    (let ((dependencies (cargo-toml-dependencies crates features)))
+    (let ((dependencies (cargo-toml-dependencies crates features paths)))
       (make-directory (file-name-directory toml) t)
       (with-temp-file toml
         (condition-case nil
@@ -272,9 +276,9 @@ kill the running process."
         (setq rustic-babel-params params)
 
         (rustic-with-spinner rustic-babel-spinner
-          (make-spinner rustic-spinner-type t 10)
-          '(rustic-babel-spinner (":Executing " (:eval (spinner-print rustic-babel-spinner))))
-          (spinner-start rustic-babel-spinner))
+                             (make-spinner rustic-spinner-type t 10)
+                             '(rustic-babel-spinner (":Executing " (:eval (spinner-print rustic-babel-spinner))))
+                             (spinner-start rustic-babel-spinner))
 
         (let ((default-directory dir))
           (write-region


### PR DESCRIPTION
This PR adds `:paths` as an accepted Org parameter, allowing the use of local dependencies in Org src snippets.