### PR TITLE
also kill buffer when using rustic-format-file

### DIFF
--- a/rustic-rustfmt.el
+++ b/rustic-rustfmt.el
@@ -147,8 +147,10 @@ and it's `cdr' is a list of arguments."
     (let ((proc-buffer (process-buffer proc)))
       (with-current-buffer proc-buffer
         (if (string-match-p "^finished" output)
-            (with-current-buffer next-error-last-buffer
-              (revert-buffer t t))
+            (and
+             (with-current-buffer next-error-last-buffer
+               (revert-buffer t t))
+             (kill-buffer proc-buffer))
           (sit-for 0.1)
           (with-current-buffer next-error-last-buffer
             (goto-char rustic-save-pos))

--- a/test/rustic-format-test.el
+++ b/test/rustic-format-test.el
@@ -26,7 +26,7 @@
         (string-dummy "can't format this string")
         (buf (get-buffer-create "test"))
         (buffer-read-only nil))
-    (kill-buffer rustic-format-buffer-name)
+    (ignore-error (kill-buffer rustic-format-buffer-name))
     (with-current-buffer buf
       (erase-buffer)
       (insert string)


### PR DESCRIPTION
@glfmn this only worked correctly for `rustic-format-buffer` not `rustic-format-file`. Thanks for opening an issue.

close #281