### PR TITLE
Polymode-based comint interaction with cargo run

### DIFF
--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -481,14 +481,7 @@ To send input to the compiled program, use
 `rustic-cargo-run-use-comint' (which see)."
   (buffer-disable-undo)
   (setq buffer-read-only nil)
-  (use-local-map comint-mode-map)
-
-  (define-key (current-local-map) (kbd "RET")
-    '(lambda ()
-       (interactive)
-       (when (eq major-mode 'rustic-cargo-run-mode)
-         (process-send-string
-          (get-buffer-process (current-buffer)) "\n")))))
+  (use-local-map comint-mode-map))
 
 (defun rustic-cargo-comint-run-mode ()
   "Mode for 'cargo run' that combines `rustic-compilation-mode' with `comint-mode',

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -483,8 +483,10 @@ If running with prefix command `C-u', read whole command from minibuffer."
   "Mode for 'cargo run' that derives from `rustic-compilation-mode'.
 
 To send input to the compiled program, use
-`rustic-compile-send-input'.  Alternatively, consider enabling
-`rustic-cargo-run-use-comint' (which see)."
+`rustic-compile-send-input'.  If you set
+`rustic-cargo-run-use-comint' to t, you can also just type in a
+string and hit RET to send it to the program.  The latter
+approach requires installing polymode."
   (buffer-disable-undo)
   (setq buffer-read-only nil)
   (use-local-map comint-mode-map))

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -470,7 +470,13 @@ If running with prefix command `C-u', read whole command from minibuffer."
 (defun rustic-cargo-run-mode ()
   (interactive)
   (if rustic-cargo-run-use-comint
-      (rustic-cargo-comint-run-mode)
+      ;; rustic-cargo-comint-run-mode toggles the mode; we want to
+      ;; always enable.
+      (unless (and (boundp 'polymode-mode)
+                   polymode-mode
+                   (memq major-mode '(rustic-cargo-plain-run-mode
+                                      comint-mode)))
+        (rustic-cargo-comint-run-mode))
     (rustic-cargo-plain-run-mode)))
 
 (define-derived-mode rustic-cargo-plain-run-mode rustic-compilation-mode "Cargo run"

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -508,15 +508,25 @@ and the latter for interacting with the compiled program."
     (define-polymode rustic-cargo-comint-run-mode
       :hostmode 'poly-rustic-cargo-compilation-hostmode
       :innermodes '(poly-rustic-cargo-comint-innermode)
-      :switch-buffer-functions '(poly-rustic-cargo-comint-switch-buffer-hook))
+      :switch-buffer-functions '(poly-rustic-cargo-comint-switch-buffer-hook)
+
+      ;; See comments in poly-rustic-cargo-comint-switch-buffer-hook below.
+      (set (make-local-variable 'pm-hide-implementation-buffers) nil)
+      )
     (put 'rustic-cargo-comint-run-mode 'function-documentation docstr)
     (rustic-cargo-comint-run-mode)))
 
 (defun poly-rustic-cargo-comint-switch-buffer-hook (old-buffer new-buffer)
   "Housekeeping for `rustic-cargo-comint-run-mode'."
+  ;; Keep inferior process attached to the visible buffer.
   (let ((proc (get-buffer-process old-buffer)))
     (when proc
-      (set-process-buffer proc new-buffer))))
+      (set-process-buffer proc new-buffer)))
+  ;; Prevent polymode from constantly renaming the
+  ;; "*rustic-compilation*" buffer.  A note in case this undocumented
+  ;; variable stops working: if that happens, you'll see
+  ;; *rustic-compilatin*[comint]<2>, <3>, etc. keep popping up.
+  (set (make-local-variable 'pm-hide-implementation-buffers) nil))
 
 ;;;###autoload
 (defun rustic-cargo-clean ()

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -5,6 +5,7 @@
 
 ;;; Code:
 
+(require 'comint)
 (require 'tabulated-list)
 
 (require 'rustic-compile)
@@ -463,7 +464,14 @@ If running with prefix command `C-u', read whole command from minibuffer."
 the keymap of `comint-mode' so user input is possible."
   (buffer-disable-undo)
   (setq buffer-read-only nil)
-  (use-local-map comint-mode-map))
+  (use-local-map comint-mode-map)
+
+  (define-key (current-local-map) (kbd "RET")
+    '(lambda ()
+       (interactive)
+       (when (eq major-mode 'rustic-cargo-run-mode)
+         (process-send-string
+          (get-buffer-process (current-buffer)) "\n")))))
 
 ;;;###autoload
 (defun rustic-cargo-clean ()


### PR DESCRIPTION
Hi, this is my attempt at addressing #295.  The dependency on polymode is entirely optional; the user needs polymode only if they enable rustic-cargo-run-use-comint.  One minor issue is its reliance on an undocumented variable in polymode, but hopefully that's OK as: a) polymode is rather careful to implement this functionality, so I don't think it'll go away in the future; b) the whole thing can be disabled if anything goes wrong.

Technical details:
rustic-cargo-run-mode is renamed to rustic-cargo-plain-run-mode.  rustic-cargo-comint-run-mode is added anew.  rustic-cargo-run-mode now refers to a wrapper mode that switches between the two depending on the setting.