### PR TITLE
Cargo run polymode

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
     - [Cargo](#cargo)
         - [Edit](#edit)
         - [Test](#test)
+        - [Run](#run)
         - [Outdated](#outdated)
     - [Clippy](#clippy)
         - [Flycheck](#flycheck)
@@ -371,6 +372,18 @@ arguments in `rustic-test-arguments`
 `rustic-cargo-current-test` run test at point, whether it's a function or a module
 
 ![](https://raw.githubusercontent.com/brotzeit/rustic/master/img/cargo_current_test.png)
+
+### Run
+
+`rustic-cargo-run` run 'cargo run'.  Input can be sent to the program
+in one of two ways:
+
+- `rustic-compile-send-input`, which reads the input from the
+  minibuffer.
+- `rustic-cargo-run-use-comint`: when this variable is set to t, the
+  input can be typed directly into the output buffer of 'cargo run'
+  and sent off with `RET`, just like in `comint-mode`.  You need
+  [polymode](https://polymode.github.io) installed for this to work.
 
 ### Outdated
 

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -469,7 +469,13 @@ If running with prefix command `C-u', read whole command from minibuffer."
 (defun rustic-cargo-run-mode ()
   (interactive)
   (if rustic-cargo-run-use-comint
-      (rustic-cargo-comint-run-mode)
+      ;; rustic-cargo-comint-run-mode toggles the mode; we want to
+      ;; always enable.
+      (unless (and (boundp 'polymode-mode)
+                   polymode-mode
+                   (memq major-mode '(rustic-cargo-plain-run-mode
+                                      comint-mode)))
+        (rustic-cargo-comint-run-mode))
     (rustic-cargo-plain-run-mode)))
 
 (define-derived-mode rustic-cargo-plain-run-mode rustic-compilation-mode "Cargo run"

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -482,8 +482,10 @@ If running with prefix command `C-u', read whole command from minibuffer."
   "Mode for 'cargo run' that derives from `rustic-compilation-mode'.
 
 To send input to the compiled program, use
-`rustic-compile-send-input'.  Alternatively, consider enabling
-`rustic-cargo-run-use-comint' (which see)."
+`rustic-compile-send-input'.  If you set
+`rustic-cargo-run-use-comint' to t, you can also just type in a
+string and hit RET to send it to the program.  The latter
+approach requires installing polymode."
   (buffer-disable-undo)
   (setq buffer-read-only nil)
   (use-local-map comint-mode-map))

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -496,7 +496,7 @@ the former for highlighting and interacting with compiler errors,
 and the latter for interacting with the compiled program."
   ;; First time around, define the mode and invoke it.  Next time, the
   ;; symbol will have been overwritten so this runs only once.
-  (unless (require 'polymode)
+  (unless (require 'polymode nil 'noerr)
     (error "polymode not found; polymode must be installed for `rustic-cargo-run-use-comint' to work"))
   (let ((docstr (documentation 'rustic-cargo-comint-run-mode)))
     (define-hostmode poly-rustic-cargo-compilation-hostmode

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -23,6 +23,14 @@ If nil then the project is simply created."
   :type 'boolean
   :group 'rustic-cargo)
 
+(defcustom rustic-cargo-run-use-comint nil
+  "If t then interact with programs in `rustic-cargo-run' using
+comint-mode.  This creates a dependency on the polymode package.
+No special configuration of polymode is needed for this to work,
+but you need to install polymode separately."
+  :type 'boolean
+  :group 'rustic-cargo)
+
 (defvar rustic-cargo-outdated-face nil)
 (make-obsolete-variable 'rustic-cargo-outdated-face
                         "use the face `rustic-cargo-outdated' instead."
@@ -458,12 +466,50 @@ If running with prefix command `C-u', read whole command from minibuffer."
                              'compile-history)))))
     (rustic-run-cargo-command command (list :mode 'rustic-cargo-run-mode))))
 
-(define-derived-mode rustic-cargo-run-mode rustic-compilation-mode "Cargo run"
-  "Mode for 'cargo run' that derives from `rustic-compilation-mode', but uses
-the keymap of `comint-mode' so user input is possible."
+(defun rustic-cargo-run-mode ()
+  (interactive)
+  (if rustic-cargo-run-use-comint
+      (rustic-cargo-comint-run-mode)
+    (rustic-cargo-plain-run-mode)))
+
+(define-derived-mode rustic-cargo-plain-run-mode rustic-compilation-mode "Cargo run"
+  "Mode for 'cargo run' that derives from `rustic-compilation-mode'.
+
+To send input to the compiled program, use
+`rustic-compile-send-input'.  Alternatively, consider enabling
+`rustic-cargo-run-use-comint' (which see)."
   (buffer-disable-undo)
   (setq buffer-read-only nil)
   (use-local-map comint-mode-map))
+
+(defun rustic-cargo-comint-run-mode ()
+  "Mode for 'cargo run' that combines `rustic-compilation-mode' with `comint-mode',
+the former for highlighting and interacting with compiler errors,
+and the latter for interacting with the compiled program."
+  ;; First time around, define the mode and invoke it.  Next time, the
+  ;; symbol will have been overwritten so this runs only once.
+  (require 'polymode)
+  (let ((docstr (documentation 'rustic-cargo-comint-run-mode)))
+    (define-hostmode poly-rustic-cargo-compilation-hostmode
+      :mode 'rustic-cargo-plain-run-mode)
+    (define-innermode poly-rustic-cargo-comint-innermode
+      :mode 'comint-mode
+      :head-matcher "^ *Running `.+`$"
+      :head-mode 'host
+      :tail-matcher "\\'"
+      :tail-mode 'host)
+    (define-polymode rustic-cargo-comint-run-mode
+      :hostmode 'poly-rustic-cargo-compilation-hostmode
+      :innermodes '(poly-rustic-cargo-comint-innermode)
+      :switch-buffer-functions '(poly-rustic-cargo-comint-switch-buffer-hook))
+    (put 'rustic-cargo-comint-run-mode 'function-documentation docstr)
+    (rustic-cargo-comint-run-mode)))
+
+(defun poly-rustic-cargo-comint-switch-buffer-hook (old-buffer new-buffer)
+  "Housekeeping for `rustic-cargo-comint-run-mode'."
+  (let ((proc (get-buffer-process old-buffer)))
+    (when proc
+      (set-process-buffer proc new-buffer))))
 
 ;;;###autoload
 (defun rustic-cargo-clean ()

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -507,15 +507,25 @@ and the latter for interacting with the compiled program."
     (define-polymode rustic-cargo-comint-run-mode
       :hostmode 'poly-rustic-cargo-compilation-hostmode
       :innermodes '(poly-rustic-cargo-comint-innermode)
-      :switch-buffer-functions '(poly-rustic-cargo-comint-switch-buffer-hook))
+      :switch-buffer-functions '(poly-rustic-cargo-comint-switch-buffer-hook)
+
+      ;; See comments in poly-rustic-cargo-comint-switch-buffer-hook below.
+      (set (make-local-variable 'pm-hide-implementation-buffers) nil)
+      )
     (put 'rustic-cargo-comint-run-mode 'function-documentation docstr)
     (rustic-cargo-comint-run-mode)))
 
 (defun poly-rustic-cargo-comint-switch-buffer-hook (old-buffer new-buffer)
   "Housekeeping for `rustic-cargo-comint-run-mode'."
+  ;; Keep inferior process attached to the visible buffer.
   (let ((proc (get-buffer-process old-buffer)))
     (when proc
-      (set-process-buffer proc new-buffer))))
+      (set-process-buffer proc new-buffer)))
+  ;; Prevent polymode from constantly renaming the
+  ;; "*rustic-compilation*" buffer.  A note in case this undocumented
+  ;; variable stops working: if that happens, you'll see
+  ;; *rustic-compilatin*[comint]<2>, <3>, etc. keep popping up.
+  (set (make-local-variable 'pm-hide-implementation-buffers) nil))
 
 ;;;###autoload
 (defun rustic-cargo-clean ()

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -496,7 +496,8 @@ the former for highlighting and interacting with compiler errors,
 and the latter for interacting with the compiled program."
   ;; First time around, define the mode and invoke it.  Next time, the
   ;; symbol will have been overwritten so this runs only once.
-  (require 'polymode)
+  (unless (require 'polymode)
+    (error "polymode not found; polymode must be installed for `rustic-cargo-run-use-comint' to work"))
   (let ((docstr (documentation 'rustic-cargo-comint-run-mode)))
     (define-hostmode poly-rustic-cargo-compilation-hostmode
       :mode 'rustic-cargo-plain-run-mode)


### PR DESCRIPTION
Attempt at addressing #295, take 2, this time targeting master.  Sorry about the clumsiness; I'm not an engineer, and not very used to collaborating on github.

(Rest of the message is same as before.)
The dependency on polymode is entirely optional; the user needs polymode only if they enable rustic-cargo-run-use-comint. One minor issue is its reliance on an undocumented variable in polymode, but hopefully that's OK as: a) polymode is rather careful to implement this functionality, so I don't think it'll go away in the future; b) the whole thing can be disabled if anything goes wrong.

Technical details:
rustic-cargo-run-mode is renamed to rustic-cargo-plain-run-mode. rustic-cargo-comint-run-mode is added anew. rustic-cargo-run-mode now refers to a wrapper mode that switches between the two depending on the setting.