### PR TITLE
Rewrite rustic-cargo using transient

### DIFF
--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -31,6 +31,11 @@ but you need to install polymode separately."
   :type 'boolean
   :group 'rustic-cargo)
 
+(defcustom rustic-cargo-always-prompt-for-arguments nil
+  "TODO"
+  :type 'boolean
+  :group 'rustic-cargo)
+
 (defvar rustic-cargo-outdated-face nil)
 (make-obsolete-variable 'rustic-cargo-outdated-face
                         "use the face `rustic-cargo-outdated' instead."
@@ -451,20 +456,27 @@ As a byproduct, you can run any shell command in your project like `pwd'"
   (setq command (read-from-minibuffer "Command to execute: " (car compile-history) nil nil 'compile-history))
   (rustic-run-cargo-command command (list :mode 'rustic-cargo-run-mode)))
 
-;;;###autoload
-(defun rustic-cargo-run (&optional arg)
+;;;###autoload (autoload 'rustic-cargo-run "rustic-cargo" nil t)
+(transient-define-prefix rustic-cargo-run (&optional transient)
   "Run 'cargo run' for the current project.
-If running with prefix command `C-u', read whole command from minibuffer."
-  (interactive "P")
-  (let* ((command (if arg
-                      (read-from-minibuffer "Cargo run command: " "cargo run ")
-                    (concat rustic-cargo-bin " run "
-                            (read-from-minibuffer
-                             "Run arguments: "
-                             (car compile-history)
-                             nil nil
-                             'compile-history)))))
-    (rustic-run-cargo-command command (list :mode 'rustic-cargo-run-mode))))
+When `rustic-cargo-always-prompt-for-arguments' is non-nil
+or with a prefix argument, then prompt for arguments."
+  ["Arguments"
+   ;; TODO add the useful ones here.
+   ]
+  ["" ("r" "run" rustic-cargo-run)]
+  (interactive
+   (list (and (not (eq transient-current-command 'rustic-cargo-run))
+              (or rustic-cargo-always-prompt-for-arguments
+                  current-prefix-arg))))
+  (if transient
+      (transient-setup 'rustic-cargo-run)
+    (rustic-run-cargo-command
+     (concat "cargo run "
+             (mapconcat #'shell-quote-argument
+                        (transient-args 'rustic-cargo-run)
+                        " "))
+     (list :mode 'rustic-cargo-run-mode))))
 
 (defun rustic-cargo-run-mode ()
   (interactive)

--- a/rustic-compile.el
+++ b/rustic-compile.el
@@ -117,7 +117,7 @@
   (let ((map (make-sparse-keymap)))
     (suppress-keymap map t)
     (set-keymap-parent map compilation-mode-map)
-    (define-key map "p" 'rustic-popup)
+    (define-key map "p" 'rustic-cargo)
     (define-key map "g" 'rustic-recompile)
     map)
   "Keymap for rust compilation log buffers.")

--- a/rustic-popup.el
+++ b/rustic-popup.el
@@ -6,235 +6,51 @@
 
 ;;; Code:
 
+(require 'transient)
+
 (require 'rustic-cargo)
 
-;;; Customization
-
-(defcustom rustic-popup-commands
-  '((?b "build"    build)
-    (?f "fmt"      fmt)
-    (?r "run"      run)
-    (?c "clippy"   clippy)
-    (?o "outdated" outdated)
-    (?e "clean"    clean)
-    (?k "check"    check)
-    (?t "test"     test)
-    (?d "doc"      doc))
-  "List of commands that are displayed in the popup.
-The first element of each list contains a command's binding."
-  :type 'list
-  :group 'rustic-popup)
-
-(define-obsolete-face-alias 'rustic-popup-key-face
-  'rustic-popup-key "1.2")
-(define-obsolete-face-alias 'rustic-popup-section-face
-  'rustic-popup-section "1.2")
-
-(defface rustic-popup-key
-  '((t (:foreground "DeepSkyBlue")))
-  "Face used for command shortcuts."
-  :group 'rustic)
-
-(defface rustic-popup-section
-  '((t (:foreground "#f74c00")))
-  "Face used for popup section description."
-  :group 'rustic)
-
-;;; Popup Mode
-
-(defvar rustic-popup-buffer-name "rustic-popup-buffer"
-  "Buffer name for rustic popup buffers.")
-
-(defvar rustic-popup-mode-map
-  (let ((map (make-sparse-keymap)))
-    (define-key map [remap self-insert-command] 'rustic-popup-invoke-popup-action)
-    (define-key map (kbd "g") 'rustic-recompile)
-    (define-key map (kbd "RET") 'rustic-popup-default-action)
-    (define-key map (kbd "<tab>") 'rustic-popup-default-action)
-    (define-key map (kbd "h") 'rustic-popup-cargo-command-help)
-    (define-key map (kbd "q") 'kill-buffer-and-window)
-    map)
-  "Keymap for rustic popup buffers.")
-
-(define-derived-mode rustic-popup-mode fundamental-mode "RusticPopup"
-  "Mode for rustic popup buffers."
-  (setq truncate-lines t)
-  (setq buffer-read-only t)
-  (setq-local scroll-margin 0))
-
-(defun rustic-popup-insert-backtrace ()
-  "Insert backtrace section."
-  (let ((inhibit-read-only t)
-        (prop (lambda (s)
-                (propertize s 'face 'rustic-popup-section))))
-    (insert (funcall prop "Backtrace: "))
-    (cond
-     ((string= rustic-compile-backtrace "0")
-      (insert " " (funcall prop "0") " | 1 | full"))
-     ((string= rustic-compile-backtrace "1")
-      (insert " 0 | " (funcall prop "1") " | full"))
-     ((string= rustic-compile-backtrace "full")
-      (insert " 0 | 1 | " (funcall prop "full")))))
-  (insert "\n\n"))
-
-(defun rustic-popup-insert-contents (buf)
-  "Insert popup buffer contents."
-  (let ((inhibit-read-only t))
-    (with-current-buffer buf
-      (erase-buffer)
-      (rustic-popup-mode)
-      (rustic-popup-insert-backtrace)
-      (insert (propertize "Commands: " 'face 'rustic-popup-section) "\n")
-      (insert " " (propertize "g" 'face 'rustic-popup-key)
-              "      " "recompile" "   " "\""
-              (or compilation-arguments rustic-compile-command)
-              "\"" "\n\n")
-      (dolist (command rustic-popup-commands)
-        (insert "\s")
-        (insert (propertize (char-to-string (nth 0 command))
-                            'face 'rustic-popup-key))
-        (insert "\s\s\s\s\s\s")
-        (insert (nth 1 command))
-        (when (and (string= (nth 1 command) "test")
-                   (> (length rustic-test-arguments) 0))
-          (insert "        " "\"" rustic-test-arguments "\""))
-        (insert "\n"))
-      (goto-char (point-min)))))
-
-;;;###autoload
-(defun rustic-popup ()
-  "Setup popup.
-If directory is not in a rust project call `read-directory-name'."
+(transient-define-prefix rustic-cargo ()
+  "Run \"cargo\"."
+  ["Environment"
+   ("B" rustic-compile-backtrace)]
+  ["cargo ..."
+   ("g" rustic-recompile
+    :description (lambda ()
+                   (let ((cmd (or compilation-arguments
+                                  rustic-compile-command)))
+                     (if (string-prefix-p "cargo " cmd)
+                         (substring cmd 6)
+                       cmd))))
+   ("b" "build"     rustic-cargo-build)
+   ("f" "fmt"       rustic-cargo-fmt)
+   ("r" "run"       rustic-cargo-run)
+   ("c" "clippy"    rustic-cargo-clippy)
+   ("o" "outdated"  rustic-cargo-outdated)
+   ("e" "clean"     rustic-cargo-clean)
+   ("k" "check"     rustic-cargo-check)
+   ("t" rustic-cargo-test
+    :description (lambda () (format "test %s" rustic-test-arguments)))
+   ("d" "doc"       rustic-cargo-doc)]
   (interactive)
-  (let ((func (lambda ()
-                (let ((buf (get-buffer-create rustic-popup-buffer-name))
-                      (win (split-window-below))
-                      (inhibit-read-only t))
-                  (rustic-popup-insert-contents buf)
-                  (set-window-buffer win buf)
-                  (select-window win)
-                  (fit-window-to-buffer)
-                  (set-window-text-height win (+ (window-height) 1))))))
-    (if (rustic-buffer-crate t)
-        (funcall func)
-      (let ((dir (read-directory-name "Rust project:")))
-        (let ((default-directory dir))
-          (if (rustic-buffer-crate t)
-              (funcall func)
-            (message "Not a rust project.")))))))
+  (if (rustic-buffer-crate t)
+      (transient-setup 'rustic-cargo)
+    (user-error "Not inside a rust project")))
 
-;;; Interactive
+(defclass rustic--compile-backtrace (transient-lisp-variable) ())
 
-;;;###autoload
-(defun rustic-popup-invoke-popup-action (event)
-  "Execute commands which are listed in `rustic-popup-commands'."
-  (interactive (list last-command-event))
-  (save-excursion
-    (let ((char (char-to-string event)))
-      (save-match-data
-        (goto-char (point-min))
-        (when (re-search-forward (concat "\s" char "\s"))
-          (goto-char (match-beginning 0)))))
-    (let* ((command (cadr (split-string
-                           (buffer-substring-no-properties
-                            (point) (line-end-position)))))
-           (c (intern (concat "rustic-cargo-" command))))
-      (if (commandp c)
-          (call-interactively c)
-        (call-interactively 'rustic-compile (concat "cargo " command))))))
+(cl-defmethod transient-infix-read ((obj rustic--compile-backtrace))
+  (let ((choices (oref obj choices)))
+    (if-let ((value (oref obj value)))
+        (or (cadr (member value choices)) "0")
+      (car choices))))
 
-;;;###autoload
-(defun rustic-popup-default-action ()
-  "Change backtrace and `compilation-arguments' when executed on
-corresponding line."
-  (interactive)
-  (let ((inhibit-read-only t))
-    (save-excursion
-      (goto-char (line-beginning-position))
-      (cond
-       ((looking-at "Backtrace:")
-        (cond
-         ((string= rustic-compile-backtrace "0")
-          (setq rustic-compile-backtrace "1"))
-         ((string= rustic-compile-backtrace "1")
-          (setq rustic-compile-backtrace "full"))
-         ((string= rustic-compile-backtrace "full")
-          (setq rustic-compile-backtrace "0")))
-        (rustic-popup-insert-contents (current-buffer)))
-       ((search-forward-regexp "\srecompile\s" (line-end-position) t)
-        (setq compilation-arguments
-              (read-string "Compilation arguments: "
-                           (or compilation-arguments rustic-compile-command)))
-        (rustic-popup-insert-contents (current-buffer)))
-       ((search-forward-regexp "\stest" (line-end-position) t)
-        (setq rustic-test-arguments
-              (read-string "Cargo test arguments: " rustic-test-arguments))
-        (rustic-popup-insert-contents (current-buffer)))
-       (t
-        (message "No default action for line."))))))
-
-;;; Help Popup
-
-(defvar rustic-popup-help-buffer-name "rustic-popup-help-buffer"
-  "Buffer name for rustic popup help buffers.")
-
-(defvar rustic-popup-help-mode-map
-  (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "q") 'rustic-popup-kill-help-buffer)
-    map)
-  "Keymap for rustic popup help buffers.")
-
-(define-derived-mode rustic-popup-help-mode fundamental-mode "RusticHelpPopup"
-  "Mode for rustic popup help buffers."
-  (setq truncate-lines t)
-  (setq buffer-read-only t)
-  (setq-local scroll-margin 0))
-
-;;;###autoload
-(defun rustic-popup-cargo-command-help ()
-  "Display help buffer for cargo command at point."
-  (interactive)
-  (let (command)
-    (save-excursion
-      (goto-char (line-beginning-position))
-      (setq command (cadr (split-string
-                           (buffer-substring-no-properties (line-beginning-position)
-                                                           (line-end-position))))))
-    (let* ((string (rustic-popup-help-flags command))
-           (inhibit-read-only t))
-      (if (not (and (> (length command) 0)
-                    (> (length (split-string string "\n")) 0)))
-          (message "No help information for command at point.")
-        (rustic-popup-setup-help-popup string)))))
-
-(defun rustic-popup-help-flags (command)
-  "Get flags of COMMAND."
-  (let ((string (shell-command-to-string (format "cargo %s -h" command)))
-        flags)
-    (dolist (s (split-string string "\n"))
-      (when (and (not (string-match "^\s+\-h" s))
-                 (string-match "^\s+\-" s))
-        (setq flags (concat flags s "\n"))))
-    flags))
-
-(defun rustic-popup-setup-help-popup (string)
-  "Switch to help buffer."
-  (let ((buf (get-buffer-create rustic-popup-help-buffer-name)))
-    (switch-to-buffer buf)
-    (erase-buffer)
-    (rustic-popup-help-mode)
-    (insert string)
-    (fit-window-to-buffer)
-    (set-window-text-height (selected-window) (+ (window-height) 1))
-    (goto-char (point-min))))
-
-;;;###autoload
-(defun rustic-popup-kill-help-buffer ()
-  "Kill popup help buffer and switch to popup buffer."
-  (interactive)
-  (switch-to-buffer rustic-popup-buffer-name)
-  (fit-window-to-buffer)
-  (set-window-text-height (selected-window) (+ (window-height) 1)))
+(transient-define-infix rustic-compile-backtrace ()
+  :class 'rustic--compile-backtrace
+  :variable 'rustic-compile-backtrace
+  :description "RUST_BACKTRACE"
+  :format " %k %d=%v"
+  :choices '("0" "1" "full"))
 
 ;;; _
 (provide 'rustic-popup)

--- a/rustic.el
+++ b/rustic.el
@@ -32,6 +32,7 @@
 (require 'pcase)
 (require 'seq)
 (require 'subr-x)
+(require 'transient)
 
 (require 'dash)
 
@@ -100,7 +101,7 @@ this variable."
 
 (defvar rustic-mode-map
   (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "C-c C-p") 'rustic-popup)
+    (define-key map (kbd "C-c C-p") 'rustic-cargo)
 
     (define-key map (kbd "C-c C-c C-u") 'rustic-compile)
     (define-key map (kbd "C-c C-c C-i") 'rustic-recompile)


### PR DESCRIPTION
As mentioned in #291.

----

Changes in behavior:

- The popup is closed after invoking a suffix.

- When the prefix is invoked outside any rust project then abort
  instead of prompting for a rust project.

- To abort the popup one has to press "C-g" instead of "q".

- The rustic-popup-commands option that controlled what suffix
  commands are shown in the popup no longer exists.  To remove a
  command one now has to use something like:

    (transient-remove-suffix 'rustic-cargo-build
                             'rustic-cargo-clippy)

- By default it is no longer possible to move around in the popup
  buffer to position the cursor on an action.  But this can be enabled
  for all transients using:

    (setq transient-enable-popup-navigation t)

- Pressing "RET" with point on a suffix in the popup buffer no longer
  invokes the "default action" in all cases.  Instead it invokes the
  selected suffix command just like pressing the respective key would.

  - Previously it was only possible to set the backtrace, compilation
    and test arguments by navigating to the respective line and
    pressing "RET" to invoke the "default action".  If popup
    navigation is enabled, then this is still possible but one can now
    also just press the key that is shown next to the variable(s).

  - Previously it was possible to show the arguments that are
    available for a command by navigating to it and then pressing
    "RET" (or "h").  That is not possible anymore, see next item.

- The ability to show the arguments supported by a command has been
  removed.  This did only show the arguments but did not let the user
  select any of them.  I believe how this was supposed to be used is
  that one would then move to the "Compilation arguments" line and
  enter arguments there.  But it seems that not every command
  respected those arguments and it is likely that not every command
  supports the same set of arguments.  It seems this was just an
  unfinished proof-of-concept.

  Instead the various commands should be defined as prefix commands as
  well, like Magit does it.  For example one of the suffix commands
  available from the `magit-dispatch` transient prefix command is
  `magit-commit`.  That in turn is also a transient prefix command,
  and when it is invoked as a suffix of `magit-dispatch`, then it is
  considered a "sub-prefix".

  I have changed one command, `rustic-cargo-run`, accordingly, but
  without actually listing the relevant arguments.  I cannot do that
  because I don`t use cargo/rust and therefor don't know which
  arguments would make sense.  Someone else will have to do that and
  also define all the other sub-prefixes.