### PR TITLE
rustic-babel: support auto wrap src block body in a `fn main` if none exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
             - [:features](#features)
             - [:paths](#paths)
             - [:toolchain](#toolchain)
+            - [:main](#main)
     - [Spinner](#spinner)
     - [inline-documentation](#inline-documentation)
         - [Prequisites](#prequisites)
@@ -79,7 +80,7 @@ The other files provide functionality that is similar to some of the features
 of rustic, however can be considered light-weight compared to some rustic's
 functionality.
 
-The shared functions and options exist as aliases in the rust-mode and 
+The shared functions and options exist as aliases in the rust-mode and
 rustic namespace for backwards compatability reasons(rustic has been a fork).
 
 ## Known issues
@@ -499,7 +500,7 @@ then a string, instead of a list, will also be accepted:
 ```
 #+BEGIN_SRC rust :crates '((tokio . 1.0)) :features '((tokio . ("rt-multi-thread" "time")))
   extern crate tokio;
-  
+
   fn main() {
       tokio::runtime::Runtime::new()
           .unwrap()
@@ -541,6 +542,28 @@ fn main() {
 : a,b,c
 ```
 
+#### :main
+
+Auto wrap whole block body in a `fn main` function call if none exists.
+
+Since this is very handy in most code snippets, so the default value is `yes`.
+`no` if you don't want this feature(for example, you don't want regex search slow things down).
+
+You can also set a default value by:
+``` elisp
+;; By setq this default to `nil`, you'll have to explict set params to ":main yes" in each block
+(setq rustic-babel-auto-wrap-main nil)
+```
+
+```
+#+begin_src rust :main yes
+let x = vec![1, 2, 3].iter().map(|&x| x + 1).collect::<Vec<_>>();
+println!("{:?}", x);
+#+end_src
+
+#+results:
+: [2, 3, 4]
+```
 
 ## Spinner
 

--- a/test/rustic-babel-test.el
+++ b/test/rustic-babel-test.el
@@ -187,3 +187,35 @@
     (with-current-buffer buf
       (rustic-test-babel-execute-block buf)
       (should (eq (rustic-test-babel-check-results buf) nil)))))
+
+(ert-deftest rustic-test-babel-ensure-main-wrap-no()
+  (let* ((string "let x = \"fn main(){}\";")
+         (params ":main no")
+         (buf (rustic-test-get-babel-block string params)))
+    (with-current-buffer buf
+      (rustic-test-babel-execute-block buf)
+      (let ((re (format "error: Could not compile `%s`.\n"
+                        (car (reverse (split-string rustic-babel-dir "/"))))))
+        (should (string= re (rustic-test-babel-check-results buf)))))))
+
+(ert-deftest rustic-test-babel-ensure-main-wrap-yes-with-main()
+  (let* ((string "
+                fn main() {
+let x = \"rustic\";
+                  }")
+         (params ":main yes")
+         (buf (rustic-test-get-babel-block string params)))
+    (with-current-buffer buf
+      (rustic-test-babel-execute-block buf)
+      (should (eq (rustic-test-babel-check-results buf) nil)))))
+
+(ert-deftest rustic-test-babel-ensure-main-wrap-no-with-main()
+  (let* ((string "
+                fn main() {
+let x = \"rustic\";
+                  }")
+         (params ":main no")
+         (buf (rustic-test-get-babel-block string params)))
+    (with-current-buffer buf
+      (rustic-test-babel-execute-block buf)
+      (should (eq (rustic-test-babel-check-results buf) nil)))))


### PR DESCRIPTION
close #267(Maybe)

related: #266

#### :main

Auto wrap whole block body in a `fn main` function call if none exists.

Since this is very handy in most code snippets, so the default value is `yes`.
`no` if you don't want this feature(for example, you don't want regex search slow things down).

You can also set a default value by:
``` elisp
;; By setq this default to `nil`, you'll have to explict set params to ":main yes" in each block
(setq rustic-babel-auto-wrap-main nil)
```

```
#+begin_src rust :main yes
let x = vec![1, 2, 3].iter().map(|&x| x + 1).collect::<Vec<_>>();
println!("{:?}", x);
#+end_src

#+results:
: [2, 3, 4]
```
