### PR TITLE
find generated babel project with rustic-babel-visit-project

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
         - [lsp-mode](#lsp-mode-1)
     - [Org-babel](#org-babel)
         - [Intro](#intro-1)
+        - [Commands](#commands)
         - [Parameters](#parameters)
             - [:crates](#crates)
             - [:features](#features)
@@ -44,6 +45,7 @@
             - [:toolchain](#toolchain)
             - [:main](#main)
             - [:include](#include)
+            - [:use](#use)
     - [Spinner](#spinner)
     - [inline-documentation](#inline-documentation)
         - [Prequisites](#prequisites)
@@ -480,6 +482,10 @@ Customization:
 - `rustic-babel-format-src-block` format block after successful build
 - `rustic-babel-display-compilation-buffer` display compilation buffer
   of babel process
+  
+### Commands
+
+- `rustic-babel-visit-project` find generated project of block at point
 
 ### Parameters
 

--- a/rustic-babel.el
+++ b/rustic-babel.el
@@ -345,5 +345,19 @@ kill the running process."
                 (set-marker (make-marker) (point) (current-buffer)))
           project)))))
 
+(defun rustic-babel-visit-project ()
+  "Open main.rs of babel block at point. The block has to be executed
+at least one time before this command can be used."
+  (interactive)
+  (let* ((beg (org-babel-where-is-src-block-head))
+         (end (save-excursion (goto-char beg)
+                              (line-end-position)))
+         (line (buffer-substring beg end))
+         (project (symbol-name (get-text-property 0 'project line)))
+         (path (concat org-babel-temporary-directory "/" project "/src/main.rs")))
+    (if (file-exists-p path)
+        (find-file path)
+      (message "Run block first to visit generated project."))))
+
 (provide 'rustic-babel)
 ;;; rustic-babel.el ends here


### PR DESCRIPTION
now that it's possible to have more complex babel projects
with the keywords :include and :use, it can be useful to
inspect the generated project