### PR TITLE
rustic-babel: and support async main for main wrap(#317)

### DIFF
--- a/rustic-babel.el
+++ b/rustic-babel.el
@@ -275,7 +275,7 @@ directory DIR."
 
 (defun rustic-babel-ensure-main-wrap (body)
   "Wrap BODY in a 'fn main' function call if none exists."
-  (if (string-match "^[ \t]*[fn]+[ \t\n\r]*main[ \t]*(.*)" body)
+  (if (string-match "^[ \t]*\\(pub \\)?\\(async \\)?[fn]+[ \t\n\r]*main[ \t]*(.*)" body)
       body
     (format "fn main() {\n%s\n}\n" body)))
 

--- a/test/rustic-babel-test.el
+++ b/test/rustic-babel-test.el
@@ -199,20 +199,29 @@
         (should (string= re (rustic-test-babel-check-results buf)))))))
 
 (ert-deftest rustic-test-babel-ensure-main-wrap-yes-with-main()
-  (let* ((string "
-                fn main() {
-let x = \"rustic\";
-                  }")
+  (let* ((string "fn main() {
+                      let x = \"rustic\";
+                 }")
          (params ":main yes")
          (buf (rustic-test-get-babel-block string params)))
     (with-current-buffer buf
       (rustic-test-babel-execute-block buf)
       (should (eq (rustic-test-babel-check-results buf) nil)))))
 
+(ert-deftest rustic-test-babel-ensure--main-wrap-yes-with-async-main()
+  (let* ((string "#[tokio::main]
+                  pub async fn main() {
+                      ()
+                 }")
+         (params ":crates '((tokio . 1.0)) :features '((tokio . (\"rt-multi-thread\" \"macros\"))) :main yes")
+         (buf (rustic-test-get-babel-block string params)))
+    (with-current-buffer buf
+      (rustic-test-babel-execute-block buf)
+      (should (eq (rustic-test-babel-check-results buf) nil)))))
+
 (ert-deftest rustic-test-babel-ensure-main-wrap-no-with-main()
-  (let* ((string "
-                fn main() {
-let x = \"rustic\";
+  (let* ((string "fn main() {
+                      let x = \"rustic\";
                   }")
          (params ":main no")
          (buf (rustic-test-get-babel-block string params)))


### PR DESCRIPTION
# Description

```org
#+begin_src :crates '((tokio . "1") (mini-redis . "0.4.1")) :main yes
#[tokio::main]
pub async fn main() -> Result<()> {
    Ok(())
}
#+end_src
```

Although `async main` is not official rust syntax, this `tokio::main` is very common. 

Adding this support would be reasonably helpful and comprehensible.

# Related Issue
close #317 
