### PR TITLE
rustic-cargo: fix cargo run --example detect crate root(#319)

### DIFF
--- a/rustic-babel.el
+++ b/rustic-babel.el
@@ -364,7 +364,7 @@ kill the running process."
         (let ((default-directory dir)
               (toolchain (cdr (assq :toolchain params))))
           (write-region
-           (concat "#![allow(non_snake_case)]\n"
+           (concat "#![allow(non_snake_case, unused)]\n"
                    (if use-blocks (rustic-babel-insert-mod use-blocks) "")
                    (if include-blocks (rustic-babel-include-blocks include-blocks) "")
                    (if wrap-main (rustic-babel-ensure-main-wrap body) body))

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -480,15 +480,14 @@ When calling this function from `rustic-popup-mode', always use the value of
 (defun rustic-cargo-run-get-relative-example-name ()
   "Run 'cargo run --example' if current buffer within a 'exmaples' directory.
 In rust, examples normally runs within single crate or a project member within workspaces."
-  (let* ((buffer-project-root (rustic-buffer-crate))
+  (let* ((buffer-project-root (rustic-buffer-project))
          (relative-filenames
           (if buffer-project-root
-              (split-string (file-relative-name buffer-file-name buffer-project-root) "/")
-            nil)))
+              (split-string (file-relative-name buffer-file-name buffer-project-root) "/") nil)))
     (if (and relative-filenames (string= "examples" (car relative-filenames)))
         (let ((size (length relative-filenames)))
-          (cond ((eq size 2) (file-name-sans-extension(nth 1 relative-filenames))) ;; examples/single-example1.rs
-                ((> size 2) (car (nthcdr (- size 2) relative-filenames))) ;; examples/example2/main.rs
+          (cond ((eq size 2) (file-name-sans-extension (nth 1 relative-filenames))) ;; examples/single-example1.rs
+                ((> size 2) (car (nthcdr (- size 2) relative-filenames)))           ;; examples/example2/main.rs
                 (t nil))) nil)))
 
 ;;;###autoload

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -478,9 +478,8 @@ When calling this function from `rustic-popup-mode', always use the value of
     (car compile-history)))
 
 (defun rustic-cargo-run-get-relative-example-name ()
-  "Run 'cargo run --example' if current buffer within a 'examples' directory.
-In rust, examples normally runs within single crate or a project member within workspaces."
-  (let* ((buffer-project-root (rustic-buffer-project))
+  "Run 'cargo run --example' if current buffer within a 'examples' directory."
+  (let* ((buffer-project-root (rustic-buffer-crate))
          (relative-filenames
           (if buffer-project-root
               (split-string (file-relative-name buffer-file-name buffer-project-root) "/") nil)))

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -478,7 +478,7 @@ When calling this function from `rustic-popup-mode', always use the value of
     (car compile-history)))
 
 (defun rustic-cargo-run-get-relative-example-name ()
-  "Run 'cargo run --example' if current buffer within a 'exmaples' directory.
+  "Run 'cargo run --example' if current buffer within a 'examples' directory.
 In rust, examples normally runs within single crate or a project member within workspaces."
   (let* ((buffer-project-root (rustic-buffer-project))
          (relative-filenames

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -478,16 +478,18 @@ When calling this function from `rustic-popup-mode', always use the value of
     (car compile-history)))
 
 (defun rustic-cargo-run-get-relative-example-name ()
-  "Run 'cargo run --example' if current buffer within a 'examples' directory."
-  (if rustic--buffer-workspace
-      (let ((relative-filenames
-             (split-string (file-relative-name buffer-file-name rustic--buffer-workspace) "/")))
-        (if (string= "examples" (car relative-filenames))
-            (let ((size (length relative-filenames)))
-              (cond ((eq size 2) (file-name-sans-extension(nth 1 relative-filenames))) ;; examples/single-example1.rs
-                    ((> size 2) (car (nthcdr (- size 2) relative-filenames))) ;; examples/example2/main.rs
-                    (t nil))) nil))
-    nil))
+  "Run 'cargo run --example' if current buffer within a 'exmaples' directory.
+In rust, examples normally runs within single crate or a project member within workspaces."
+  (let* ((buffer-project-root (rustic-buffer-crate))
+         (relative-filenames
+          (if buffer-project-root
+              (split-string (file-relative-name buffer-file-name buffer-project-root) "/")
+            nil)))
+    (if (and relative-filenames (string= "examples" (car relative-filenames)))
+        (let ((size (length relative-filenames)))
+          (cond ((eq size 2) (file-name-sans-extension(nth 1 relative-filenames))) ;; examples/single-example1.rs
+                ((> size 2) (car (nthcdr (- size 2) relative-filenames))) ;; examples/example2/main.rs
+                (t nil))) nil)))
 
 ;;;###autoload
 (defun rustic-run-shell-command (&optional arg)

--- a/rustic.el
+++ b/rustic.el
@@ -75,17 +75,6 @@
                (dir (file-name-directory (cdr (assoc-string "root" output)))))
           (setq rustic--buffer-workspace dir))))))
 
-(defun rustic-buffer-project ()
-  "Locate project(crate) root."
-  (with-temp-buffer
-    (let ((ret (call-process rustic-cargo-bin nil t nil "locate-project")))
-      (when (/= ret 0)
-        (error "`cargo locate-project' returned %s status: %s" ret (buffer-string)))
-      (goto-char 0)
-      (let* ((output (json-read))
-             (dir (cdr (assoc-string "root" output))))
-        (file-name-directory (directory-file-name dir))))))
-
 (defun rustic-buffer-crate (&optional nodefault)
   "Return the crate for the current buffer.
 When called outside a Rust project, then return `default-directory',

--- a/rustic.el
+++ b/rustic.el
@@ -75,6 +75,17 @@
                (dir (file-name-directory (cdr (assoc-string "root" output)))))
           (setq rustic--buffer-workspace dir))))))
 
+(defun rustic-buffer-project ()
+  "Locate project(crate) root."
+  (with-temp-buffer
+    (let ((ret (call-process rustic-cargo-bin nil t nil "locate-project")))
+      (when (/= ret 0)
+        (error "`cargo locate-project' returned %s status: %s" ret (buffer-string)))
+      (goto-char 0)
+      (let* ((output (json-read))
+             (dir (cdr (assoc-string "root" output))))
+        (file-name-directory (directory-file-name dir))))))
+
 (defun rustic-buffer-crate (&optional nodefault)
   "Return the crate for the current buffer.
 When called outside a Rust project, then return `default-directory',


### PR DESCRIPTION
# Close #319
This commit -> 7544d8179b5f7f59aa98d45fe4cd4a127e13bbf1 shows the `buffer-workspaces` may have some other issues.

And by the way, the `examples`  should normally run within a single crate, which I did not notice before.