### PR TITLE
rustic-buffer-workspace should return the directory instead of Cargo.toml

### DIFF
--- a/rustic.el
+++ b/rustic.el
@@ -72,7 +72,8 @@
           (error "`cargo locate-project' returned %s status: %s" ret (buffer-string)))
         (goto-char 0)
         (let* ((output (json-read))
-               (dir (cdr (assoc-string "root" output))))
+               (dir (replace-regexp-in-string "/Cargo.toml$" ""
+                                              (cdr (assoc-string "root" output)))))
           (setq rustic--buffer-workspace dir))))))
 
 (defun rustic-buffer-crate (&optional nodefault)

--- a/rustic.el
+++ b/rustic.el
@@ -72,8 +72,7 @@
           (error "`cargo locate-project' returned %s status: %s" ret (buffer-string)))
         (goto-char 0)
         (let* ((output (json-read))
-               (dir (replace-regexp-in-string "/Cargo.toml$" ""
-                                              (cdr (assoc-string "root" output)))))
+               (dir (file-name-directory (cdr (assoc-string "root" output)))))
           (setq rustic--buffer-workspace dir))))))
 
 (defun rustic-buffer-crate (&optional nodefault)


### PR DESCRIPTION
rustic-compile-directory-method expects a function that returns the path to a directory.

Setting `(setq rustic-compile-directory-method 'rustic-buffer-workspace)` seems to have an issue when 
rustic-buffer-workspace returns /root/of/workspace/Cargo.toml.   In this case, rustic-cargo-check fails with the message:
```
apply: Setting current directory: Not a directory, /root/of/workspace/Cargo.toml
```

This patch removes the /Cargo.toml from the path, so that rustic-buffer-workspace returns the parent dir.

