### PR TITLE
Rustic doc housekeeping

### DIFF
--- a/README.md
+++ b/README.md
@@ -686,13 +686,13 @@ types](https://github.com/Malabarba/spinner.el/blob/master/spinner.el#L104)).
 
 ## inline-documentation
 
-With some setup, it is possible to read rust documentation inside
-Emacs! This currently requires LSP-mode.  ![Rustic-doc
+It is possible to read rust documentation inside
+Emacs! This currently requires LSP-mode and cargo.  ![Rustic-doc
 example](img/rustic-doc.png)
 
 ### Prequisites
 
-* Install Pandoc https://pandoc.org/installing.html
+* Install Pandoc, preferably at least version 2.11, as it will give somewhat nicer generated documentation: https://pandoc.org/installing.html
 * Install cargo
   https://doc.rust-lang.org/cargo/getting-started/installation.html
 * Install helm-ag https://github.com/emacsorphanage/helm-ag (Optional,
@@ -725,9 +725,6 @@ example](img/rustic-doc.png)
 
 ### Notes
 
-* We are waiting for an update to Pandoc that will make the generated
-  documents prettier, it should be available soon
-  https://github.com/jgm/pandoc/issues/6554
 * You should re-run `rustic-doc-setup` once in a while, to update the
   pandoc filter.
 * If rustic-doc does not find the documentation for something, the

--- a/rustic-doc.el
+++ b/rustic-doc.el
@@ -263,11 +263,6 @@ See buffer *cargo-makedocs* for more info")
           (let* ((docs-src
                   (concat (file-name-as-directory rustic-doc-current-project)
                           "target/doc"))
-                 ;; FIXME: Many projects could share the same docs.
-                 ;; *However* that would have to be versioned, so
-                 ;; we'll have to figure out a way to coerce `<crate>-<version>`
-                 ;; strings out of cargo, or just parse the Cargo.toml file, but
-                 ;; then we'd have to review different parsing solutions.
                  (finish-func (lambda (_p)
                                 (message "Finished converting docs for %s"
                                          rustic-doc-current-project))))
@@ -277,7 +272,8 @@ See buffer *cargo-makedocs* for more info")
                                        finish-func
                                        docs-src
                                        (rustic-doc--project-doc-dest)))))
-    (message "Could not find project to convert. Visit a rust project first! \
+    (message "If you want to convert the documentation for the dependencies in a project,
+visit the project and run `rustic-doc-convert-current-package'! \
 \(Or activate rustic-doc-mode if you are in one)")))
 
 (defun rustic-doc-install-deps ()
@@ -314,7 +310,8 @@ NO-DL is primarily used for development of the filters."
                              rustic-doc-convert-prog
                              (lambda (_p)
                                (message "Finished converting docs for std"))
-                             "std"))
+                             "std")
+  (rustic-doc-convert-current-package))
 
 (defun rustic-doc--start-process (name program finish-func &rest program-args)
   (let* ((buf (generate-new-buffer (concat "*" name "*")))

--- a/rustic-doc.el
+++ b/rustic-doc.el
@@ -298,11 +298,15 @@ See buffer *cargo-makedocs* for more info")
                                      "install" "cargo-makedocs"))))))
 
 ;;;###autoload
-(defun rustic-doc-setup ()
-  "Setup or update rustic-doc filter and convert script. Convert std."
+(defun rustic-doc-setup (&optional no-dl)
+  "Setup or update rustic-doc filter and convert script. Convert std.
+If NO-DL is non-nil, will not try to re-download
+the pandoc filter and bash script.
+NO-DL is primarily used for development of the filters."
   (interactive)
-  (rustic-doc--install-resources)
-  (rustic-doc-install-deps)
+  (unless no-dl
+    (rustic-doc--install-resources)
+    (rustic-doc-install-deps))
   (message "Setup is converting the standard library")
   (delete-directory (concat rustic-doc-save-loc "/std")
                     t)


### PR DESCRIPTION
* Run `rustic-doc-convert-current-package` after setup.
* Update documentation
* Add optional argument to `rustic-doc-setup` to avoid re-downloading online resources.