### PR TITLE
Fix macro expanding, remove incorrect nightly check

### DIFF
--- a/rustic-lsp.el
+++ b/rustic-lsp.el
@@ -134,12 +134,22 @@ with `lsp-rust-switch-server'."
 
 (define-derived-mode rustic-macro-expansion-mode special-mode "Rust"
   :group 'rustic
-  :syntax-table rustic-mode-syntax-table
+
+  :syntax-table rust-mode-syntax-table
+
+  ;; Syntax
+  (setq-local syntax-propertize-function #'rust-syntax-propertize)
+
+  ;; Indentation
+  (setq-local indent-line-function 'rust-mode-indent-line)
+
   ;; Fonts
-  (setq-local font-lock-defaults '(rust-font-lock-keywords
-                                   nil nil nil nil
-                                   (font-lock-syntactic-face-function
-                                    . rust-mode-syntactic-face-function))))
+  (setq-local font-lock-defaults
+              '(rust-font-lock-keywords
+                nil nil nil nil
+                (font-lock-syntactic-face-function
+                 . rust-mode-syntactic-face-function)))
+  )
 
 ;;;###autoload
 (defun rustic-analyzer-macro-expand (result)
@@ -152,18 +162,13 @@ with `lsp-rust-switch-server'."
       (let ((inhibit-read-only t))
         (erase-buffer)
         ;; wrap expanded macro in a main function so we can run rustfmt
-        (insert "fn main()")
+        (insert "fn main() {")
         ;; rustfmt complains about $s
         (insert (replace-regexp-in-string "\\$" "" result))
+        (insert "}")
         (rustic-macro-expansion-mode)
-        (rustic-format-buffer)
-        (with-current-buffer buf
-          (save-excursion
-            (goto-char (point-min))
-            (delete-region (point-min) (line-end-position))
-            (goto-char (point-max))
-            (forward-line -1)
-            (delete-region (line-beginning-position) (point-max))))))
+
+        (rustic-format-macro-buffer)))
     (display-buffer buf)))
 
 ;;; _

--- a/rustic-rustfmt.el
+++ b/rustic-rustfmt.el
@@ -281,10 +281,7 @@ This operation requires a nightly version of rustfmt.
 
 ;;;###autoload
 (defun rustic-format-buffer ()
-  "Format the current buffer using rustfmt.
-
-Provide optional argument NO-STDIN for `rustic-before-save-hook' since there
-were issues when using stdin for formatting."
+  "Format the current buffer using rustfmt."
   (interactive)
   (unless (or (eq major-mode 'rustic-mode)
               (eq major-mode 'rustic-macro-expansion-mode))
@@ -295,10 +292,7 @@ were issues when using stdin for formatting."
                                :stdin (buffer-string)))
 
 (defun rustic-format-macro-buffer ()
-  "Format the current buffer with macro output using rustfmt.
-
-Provide optional argument NO-STDIN for `rustic-before-save-hook' since there
-were issues when using stdin for formatting."
+  "Format the current buffer using rustfmt, and theh remove first and last lines."
   (interactive)
   (unless (or (eq major-mode 'rustic-mode)
               (eq major-mode 'rustic-macro-expansion-mode))

--- a/rustic-rustfmt.el
+++ b/rustic-rustfmt.el
@@ -168,6 +168,28 @@ and it's `cdr' is a list of arguments."
           (funcall rustic-format-display-method proc-buffer)
           (message "Rustfmt error."))))))
 
+(defun rustic-format-macro-sentinel (proc output)
+  "Format buffer and remove decorations that we create for rustfmt"
+  (rustic-format-sentinel proc output)
+  (with-current-buffer next-error-last-buffer
+    (save-excursion
+      (read-only-mode -1)
+      ;; remove fn __main() {
+      (goto-char (point-min))
+      (delete-region (point-min) (line-end-position))
+      (delete-blank-lines)
+      (goto-char (point-max))
+      ;; remove } from fn __main()
+      (forward-line -1)
+      (delete-region (line-beginning-position) (point-max))
+      ;; reindent buffer to left
+      (indent-region (point-min) (point-max))
+      (goto-char (point-max))
+      ;; clean blanked line
+      ;; (delete-blank-lines)
+      (delete-trailing-whitespace (point-min) (point-max)))))
+
+
 (defun rustic-format-file-sentinel (proc output)
   "Sentinel for rustfmt processes when formatting a file."
   (ignore-errors
@@ -243,8 +265,6 @@ This operation requires a nightly version of rustfmt.
               (eq major-mode 'rustic-macro-expansion-mode))
     (error "Not a rustic-mode buffer."))
   (if (not (region-active-p)) (rustic-format-buffer)
-    (unless (equal (call-process "cargo" nil nil nil "+nightly") 0)
-      (error "Need nightly toolchain to format region."))
     (let* ((buf (current-buffer))
            (file (buffer-file-name buf))
            (start (rustic--get-line-number begin))
@@ -271,6 +291,20 @@ were issues when using stdin for formatting."
     (error "Not a rustic-mode buffer."))
   (rustic-compilation-process-live t)
   (rustic-format-start-process 'rustic-format-sentinel
+                               :buffer (current-buffer)
+                               :stdin (buffer-string)))
+
+(defun rustic-format-macro-buffer ()
+  "Format the current buffer with macro output using rustfmt.
+
+Provide optional argument NO-STDIN for `rustic-before-save-hook' since there
+were issues when using stdin for formatting."
+  (interactive)
+  (unless (or (eq major-mode 'rustic-mode)
+              (eq major-mode 'rustic-macro-expansion-mode))
+    (error "Not a rustic-mode buffer."))
+  (rustic-compilation-process-live t)
+  (rustic-format-start-process 'rustic-format-macro-sentinel
                                :buffer (current-buffer)
                                :stdin (buffer-string)))
 


### PR DESCRIPTION
Fix macro expanding, remove incorrect nightly check in rustic-format-region, update syntax and idents in rustic-macro-expansion-mode