### PR TITLE
remove duplicate args in rustic-cargo-run-test

### DIFF
--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -134,7 +134,7 @@ When calling this function from `rustic-popup-mode', always use the value of
 
 (defun rustic-cargo-run-test (test)
   (let* ((command (list (rustic-cargo-bin) "test" test))
-         (c (append command (split-string rustic-test-arguments)))
+         (c (append command))
          (buf rustic-test-buffer-name)
          (proc rustic-test-process-name)
          (mode 'rustic-cargo-test-mode))


### PR DESCRIPTION
Fixes error caused by duplicate test names being passed to `cargo test`.

Fixes https://github.com/brotzeit/rustic/issues/366.