### PR TITLE
Universal argument for cargo clean command

### DIFF
--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -6,6 +6,8 @@
 ;;; Code:
 
 (require 'tabulated-list)
+(require 'dash)
+(require 's)
 
 (require 'rustic-compile)
 (require 'rustic-interaction) ; for rustic-beginning-of-function
@@ -517,11 +519,28 @@ in your project like `pwd'"
   (rustic-run-cargo-command (list (rustic-cargo-bin) "build")
                             (list :clippy-fix t)))
 
+(defvar rustic-clean-arguments nil
+  "Holds arguments for 'cargo clean', similar to `compilation-arguments`.")
+
 ;;;###autoload
-(defun rustic-cargo-clean ()
-  "Run 'cargo clean' for the current project."
-  (interactive)
-  (rustic-run-cargo-command (list (rustic-cargo-bin) "clean")))
+(defun rustic-cargo-clean (&optional arg)
+  "Run 'cargo clean' for the current project.
+
+If ARG is not nil, use value as argument and store it in `rustic-clean-arguments'.
+When calling this function from `rustic-popup-mode', always use the value of
+`rustic-clean-arguments'."
+  (interactive "P")
+  (message "%s" arg)
+  (rustic-run-cargo-command
+   (-filter (lambda (s) (s-present? s))
+            (-flatten
+             (list (rustic-cargo-bin) "clean"
+                   (cond (arg
+                          (setq rustic-clean-arguments
+                                (s-split " "
+                                         (read-from-minibuffer "Cargo clean arguments: "
+                                                               (s-join " " rustic-clean-arguments)))))
+                         (t rustic-clean-arguments)))))))
 
 ;;;###autoload
 (defun rustic-cargo-check ()

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -530,7 +530,6 @@ If ARG is not nil, use value as argument and store it in `rustic-clean-arguments
 When calling this function from `rustic-popup-mode', always use the value of
 `rustic-clean-arguments'."
   (interactive "P")
-  (message "%s" arg)
   (rustic-run-cargo-command
    (-filter (lambda (s) (s-present? s))
             (-flatten


### PR DESCRIPTION
This makes it quite similar to the other functions like build, run commands present in the rustic mode.

My personal use case is to pass `-p package_name` as I'm hitting this bug way too often currently: https://github.com/rust-lang/rust/issues/84970