### PR TITLE
Insert command into the compilation buffer

### DIFF
--- a/rustic-compile.el
+++ b/rustic-compile.el
@@ -288,9 +288,8 @@ ARGS is a plist that affects how the process is run.
     (unless (plist-get args :no-display)
       (funcall rustic-compile-display-method buf))
     (with-current-buffer buf
-      (read-only-mode -1)
-      (insert (format "%s \n" (s-join " "  command)))
-      (read-only-mode 1)
+      (let ((inhibit-read-only t))
+        (insert (format "%s \n" (s-join " "  command))))
       (rustic-make-process :name process
                            :buffer buf
                            :command command

--- a/rustic-compile.el
+++ b/rustic-compile.el
@@ -11,6 +11,7 @@
 
 (require 'markdown-mode)
 (require 'xterm-color)
+(require 's)
 
 (require 'compile)
 
@@ -287,6 +288,9 @@ ARGS is a plist that affects how the process is run.
     (unless (plist-get args :no-display)
       (funcall rustic-compile-display-method buf))
     (with-current-buffer buf
+      (read-only-mode -1)
+      (insert (format "%s \n" (s-join " "  command)))
+      (read-only-mode 1)
       (rustic-make-process :name process
                            :buffer buf
                            :command command


### PR DESCRIPTION
Fixes #372

Sample `rustic-cargo-clean`:

``` shellsession
cargo clean

rust-compilation finished at Fri Jan 28 08:51:40
```

And when we pass custom parameter:

``` shellsession
cargo clean -p package

rust-compilation finished at Fri Jan 28 08:54:06
```