### PR TITLE
Fix bugs in rustic-cargo-outdated-mode

### DIFF
--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -257,6 +257,15 @@ Execute process in PATH."
     (with-current-buffer (process-buffer proc)
       (insert output))))
 
+(defun rustic-cargo-outdated--skip-to-packages ()
+  "Move line forward till we reach the package name."
+  (goto-char (point-min))
+  (let ((line (buffer-substring-no-properties (line-beginning-position) (line-end-position))))
+    (while (not (or (eobp) (s-starts-with? "--" line)))
+      (forward-line 1)
+      (setf line (buffer-substring-no-properties (line-beginning-position) (line-end-position))))
+    (when (s-starts-with? "--" line) (forward-line 1))))
+
 (defun rustic-cargo-outdated-sentinel (proc _output)
   "Sentinel for rustic-cargo-outdated-process."
   (let ((buf (process-buffer proc))
@@ -264,8 +273,7 @@ Execute process in PATH."
         (exit-status (process-exit-status proc)))
     (if (zerop exit-status)
         (with-current-buffer buf
-          (goto-char (point-min))
-          (forward-line 2)
+          (rustic-cargo-outdated--skip-to-packages)
           (let ((packages (split-string
                            (buffer-substring (point) (point-max)) "\n" t)))
             (erase-buffer)

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -362,7 +362,7 @@ Execute process in PATH."
 (defun rustic-cargo--outdated-make-crate (crate-line)
   "Create RUSTIC-CRATE struct out of a CRATE-LINE.
 
-The CREATE-LINE is a single line from the `rustic-cargo-oudated-buffer-name'"
+The CRATE-LINE is a single line from the `rustic-cargo-oudated-buffer-name'"
   (make-rustic-crate :name (nth 1 crate-line) :version (nth 2 crate-line)))
 
 ;;;###autoload
@@ -377,7 +377,7 @@ The CREATE-LINE is a single line from the `rustic-cargo-oudated-buffer-name'"
       (user-error "No operations specified"))))
 
 (defun rustic-cargo--outdated-get-crates (cargo-outdated-buffer-string)
-  "Return a list of RUSTIC-CRATE which needs to be updated.
+  "Return a list of `rustic-crate' which needs to be updated.
 
  CARGO-OUTDATED-BUFFER-STRING represents the entire buffer of
 `rustic-cargo-oudated-buffer-name'"


### PR DESCRIPTION
Fixes two bugs:
- Fixes a bug when dependencies are specified as git repositories:

The `cargo outdated --depth 1` doesn't always gives the package from line number 2. For a sample project I'm having this is the output it gives:

``` shellsession
❯ cargo outdated --depth 1
    Updating git repository `https://github.com/snoyberg/async-refresh-rs`
Name           Project  Compat   Latest   Kind    Platform
----           -------  ------   ------   ----    --------
anyhow         1.0.40   1.0.53   1.0.53   Normal  ---
askama         0.10.5   ---      0.11.0   Normal  ---
```

As you can see in the above case, the hardcoding of the value 2 doesn't work. The above scenario, makes cargo outdated stuff to break entirely. Infact, for me the buffer was empty and the sentinel function broke. The fix instead tries to check for `--` 
 character to delimit where the packages are starting from.

- Fix cargo upgrade when you update version to latest version

Right now, rustic-cargo-upgrade-execute only works when we try to upgrade it to a compabible version ie

``` shellsession
Name           Project  Compat   Latest   Kind    Platform
----           -------  ------   ------   ----    --------
anyhow         1.0.40   1.0.53   1.0.53   Normal  ---
```

Trying to upgrade above will work. But this will fail:

``` shellsession
Name           Project  Compat   Latest   Kind    Platform
----           -------  ------   ------   ----    --------
askama         0.10.5   ---      0.11.0   Normal  ---
```

And the reason is that it tries to use this code `(elt crate 2)` for taking the version from. But this makes it to work only when the
`compat` column is already filled. Also because of the way `tabulated-list` works, we just change the buffer when we do `rustic-cargo-mark-upgrade`. This commit fixes it in such a way that it works for all the cases.

