### PR TITLE
Add ability to upgrade to latest version in rustic-outdated-mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,8 +500,10 @@ can use most commands you know from the emacs package menu. This
 option requires the rust package `cargo-outdated` to be installed
 before being used.
 
-- `u` mark single crate for upgrade
-- `U` mark all upgradable crates
+- `u` mark single crate for upgrade. Asks using minibuffer the exact
+  version that should be used for upgrade.
+- `U` mark all upgradable crates.
+- `l` mark single crate for upgrading to latest available package
 - `m` remove mark
 - `x` perform marked package menu actions
 - `r` refresh crate list

--- a/README.md
+++ b/README.md
@@ -504,6 +504,7 @@ before being used.
   version that should be used for upgrade.
 - `U` mark all upgradable crates.
 - `l` mark single crate for upgrading to latest available package
+- `L` mark all crates to latest available package
 - `m` remove mark
 - `x` perform marked package menu actions
 - `r` refresh crate list

--- a/README.md
+++ b/README.md
@@ -500,11 +500,10 @@ can use most commands you know from the emacs package menu. This
 option requires the rust package `cargo-outdated` to be installed
 before being used.
 
-- `u` mark single crate for upgrade. Asks using minibuffer the exact
-  version that should be used for upgrade.
+- `u` mark single crate for upgrade and prompt user for version.
 - `U` mark all upgradable crates.
-- `l` mark single crate for upgrading to latest available package
-- `L` mark all crates to latest available package
+- `l` mark single crate for upgrading to latest version.
+- `L` mark all crates to latest version.
 - `m` remove mark
 - `x` perform marked package menu actions
 - `r` refresh crate list

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -214,6 +214,7 @@ When calling this function from `rustic-popup-mode', always use the value of
     (define-key map (kbd "x") 'rustic-cargo-upgrade-execute)
     (define-key map (kbd "r") 'rustic-cargo-reload-outdated)
     (define-key map (kbd "l") 'rustic-cargo-mark-latest-upgrade)
+    (define-key map (kbd "L") 'rustic-cargo-mark-all-upgrades-latest)
     (define-key map (kbd "c") 'rustic-compile)
     (define-key map (kbd "q") 'quit-window)
     map)
@@ -371,6 +372,31 @@ Execute process in PATH."
                                        'font-lock-face
                                        'rustic-cargo-outdated-upgrade)))))
       (tabulated-list-put-tag "U" t))))
+
+;;;###autoload
+(defun rustic-cargo-mark-all-upgrades-latest ()
+  "Mark all packages in the Package Menu to latest version."
+  (interactive)
+  (save-excursion
+    (goto-char (point-min))
+    (while (not (eobp))
+      (let ((crate (aref (tabulated-list-get-entry) 0))
+            (current-version (aref (tabulated-list-get-entry) 1))
+            (latest-version (aref (tabulated-list-get-entry) 3))
+            (inhibit-read-only t))
+        (goto-char (line-beginning-position))
+        (save-match-data
+          (when (search-forward crate)
+            (replace-match (propertize crate
+                                       'font-lock-face
+                                       'rustic-cargo-outdated-upgrade)))
+          (goto-char (line-beginning-position))
+          (when (search-forward current-version)
+            (replace-match (propertize latest-version
+                                       'font-lock-face
+                                       'rustic-cargo-outdated-upgrade))))
+        (tabulated-list-put-tag "U")
+        (forward-line)))))
 
 ;;;###autoload
 (defun rustic-cargo-mark-all-upgrades ()

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -357,10 +357,11 @@ Execute process in PATH."
   (interactive)
   (let* ((crate (tabulated-list-get-entry (point)))
          (v (substring-no-properties (elt crate 3)))
+         (line-beg (line-beginning-position))
          (inhibit-read-only t))
     (when v
       (save-excursion
-        (goto-char (line-beginning-position))
+        (goto-char line-beg)
         (save-match-data
           (when (search-forward (elt crate 0))
             (replace-match (propertize (elt crate 0)

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -382,21 +382,23 @@ Execute process in PATH."
   (save-excursion
     (goto-char (point-min))
     (while (not (eobp))
-      (let ((crate (aref (tabulated-list-get-entry) 0))
-            (current-version (aref (tabulated-list-get-entry) 1))
-            (latest-version (aref (tabulated-list-get-entry) 3))
-            (inhibit-read-only t))
-        (goto-char (line-beginning-position))
-        (save-match-data
-          (when (search-forward crate)
-            (replace-match (propertize crate
-                                       'font-lock-face
-                                       'rustic-cargo-outdated-upgrade)))
-          (goto-char (line-beginning-position))
-          (when (search-forward current-version)
-            (replace-match (propertize latest-version
-                                       'font-lock-face
-                                       'rustic-cargo-outdated-upgrade))))
+      (let* ((crate (aref (tabulated-list-get-entry) 0))
+             (current-version (aref (tabulated-list-get-entry) 1))
+             (latest-version (aref (tabulated-list-get-entry) 3))
+             (line-beg (line-beginning-position))
+             (highlight-text (lambda ()
+                               (save-match-data
+                                 (when (search-forward crate)
+                                   (replace-match (propertize crate
+                                                              'font-lock-face
+                                                              'rustic-cargo-outdated-upgrade)))
+                                 (goto-char line-beg)
+                                 (when (search-forward current-version)
+                                   (replace-match (propertize latest-version
+                                                              'font-lock-face
+                                                              'rustic-cargo-outdated-upgrade))))))
+             (inhibit-read-only t))
+        (funcall highlight-text)
         (tabulated-list-put-tag "U")
         (forward-line)))))
 

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -213,6 +213,7 @@ When calling this function from `rustic-popup-mode', always use the value of
     (define-key map (kbd "U") 'rustic-cargo-mark-all-upgrades)
     (define-key map (kbd "x") 'rustic-cargo-upgrade-execute)
     (define-key map (kbd "r") 'rustic-cargo-reload-outdated)
+    (define-key map (kbd "l") 'rustic-cargo-mark-latest-upgrade)
     (define-key map (kbd "c") 'rustic-compile)
     (define-key map (kbd "q") 'quit-window)
     map)
@@ -333,6 +334,28 @@ Execute process in PATH."
   (let* ((crate (tabulated-list-get-entry (point)))
          (v (read-from-minibuffer "Update to version: "
                                   (substring-no-properties (elt crate 2))))
+         (inhibit-read-only t))
+    (when v
+      (save-excursion
+        (goto-char (line-beginning-position))
+        (save-match-data
+          (when (search-forward (elt crate 0))
+            (replace-match (propertize (elt crate 0)
+                                       'font-lock-face
+                                       'rustic-cargo-outdated-upgrade)))
+          (goto-char (line-beginning-position))
+          (when (search-forward (elt crate 1))
+            (replace-match (propertize v
+                                       'font-lock-face
+                                       'rustic-cargo-outdated-upgrade)))))
+      (tabulated-list-put-tag "U" t))))
+
+;;;###autoload
+(defun rustic-cargo-mark-latest-upgrade ()
+  "Mark an upgradable package to the latest available version."
+  (interactive)
+  (let* ((crate (tabulated-list-get-entry (point)))
+         (v (substring-no-properties (elt crate 3)))
          (inhibit-read-only t))
     (when v
       (save-excursion

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -378,6 +378,7 @@ Execute process in PATH."
 (defun rustic-cargo-mark-all-upgrades-latest ()
   "Mark all packages in the Package Menu to latest version."
   (interactive)
+  (tabulated-list-print t)
   (save-excursion
     (goto-char (point-min))
     (while (not (eobp))

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -386,19 +386,18 @@ Execute process in PATH."
              (current-version (aref (tabulated-list-get-entry) 1))
              (latest-version (aref (tabulated-list-get-entry) 3))
              (line-beg (line-beginning-position))
-             (highlight-text (lambda ()
-                               (save-match-data
-                                 (when (search-forward crate)
-                                   (replace-match (propertize crate
-                                                              'font-lock-face
-                                                              'rustic-cargo-outdated-upgrade)))
-                                 (goto-char line-beg)
-                                 (when (search-forward current-version)
-                                   (replace-match (propertize latest-version
-                                                              'font-lock-face
-                                                              'rustic-cargo-outdated-upgrade))))))
+             (replace-highlight-text
+              (lambda (text)
+                (replace-match (propertize text
+                                           'font-lock-face
+                                           'rustic-cargo-outdated-upgrade))))
              (inhibit-read-only t))
-        (funcall highlight-text)
+        (save-match-data
+          (when (search-forward crate)
+            (funcall replace-highlight-text crate))
+          (goto-char line-beg)
+          (when (search-forward current-version)
+            (funcall replace-highlight-text latest-version)))
         (tabulated-list-put-tag "U")
         (forward-line)))))
 


### PR DESCRIPTION
Implements two features:

- Ability to mark a specific crate to upgrade it to the latest available version
- Ability to mark all creates to upgrade to the latest available version

The README has also been updated with the relevant documentation.