### PR TITLE
[cargo] add cargo-build-arguments as variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,7 @@ Customization:
 
 - `rustic-cargo-bin` Path to cargo executable
 - `rustic-cargo-bin-remote` Path to remote cargo executable
+- `rustic-cargo-build-arguments` default arguments for cargo build
 - `rustic-cargo-check-arguments` default arguments for cargo check
 
 ### Edit

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -50,6 +50,11 @@ If nil then the project is simply created."
   :type 'string
   :group 'rustic-cargo)
 
+(defcustom rustic-cargo-build-arguments ""
+  "Default arguments when running 'cargo build'."
+  :type 'string
+  :group 'rustic-cargo)
+
 (defvar rustic-cargo-outdated-face nil)
 (make-obsolete-variable 'rustic-cargo-outdated-face
                         "use the face `rustic-cargo-outdated' instead."
@@ -600,8 +605,9 @@ in your project like `pwd'"
 (defun rustic-cargo-build ()
   "Run 'cargo build' for the current project."
   (interactive)
-  (rustic-run-cargo-command (list (rustic-cargo-bin) "build")
-                            (list :clippy-fix t)))
+  (rustic-run-cargo-command (list (rustic-cargo-bin)
+                                  "build" rustic-cargo-build-arguments))
+                            (list :clippy-fix t))
 
 (defvar rustic-clean-arguments nil
   "Holds arguments for 'cargo clean', similar to `compilation-arguments`.")

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -605,8 +605,9 @@ in your project like `pwd'"
 (defun rustic-cargo-build ()
   "Run 'cargo build' for the current project."
   (interactive)
-  (rustic-run-cargo-command (list (rustic-cargo-bin)
-                                  "build" rustic-cargo-build-arguments))
+  (rustic-run-cargo-command `(,(rustic-cargo-bin)
+                              "build"
+                              ,@(split-string rustic-cargo-build-arguments)))
                             (list :clippy-fix t))
 
 (defvar rustic-clean-arguments nil

--- a/test/rustic-cargo-test.el
+++ b/test/rustic-cargo-test.el
@@ -191,6 +191,22 @@ fn test21() {
     (should (= 0 (length (split-string rustic-test-arguments))))
     (kill-buffer buf)))
 
+(ert-deftest rustic-test-build ()
+  (let* ((string "fn main() { let s = 1;}")
+         (buf (rustic-test-count-error-helper-new string))
+         (default-directory (file-name-directory (buffer-file-name buf)))
+         (rustic-cargo-build-arguments "--all-targets"))
+    (with-current-buffer buf
+      (call-interactively 'rustic-cargo-build)
+      (let* ((proc (get-process rustic-compilation-process-name))
+             (buffer (process-buffer proc)))
+        (while (eq (process-status proc) 'run)
+          (sit-for 0.01))
+
+        (should (string= (s-join " " (process-get proc 'command))
+                             (concat (rustic-cargo-bin) " build "
+                                     rustic-cargo-build-arguments)))))))
+
 (ert-deftest rustic-test-check ()
   (let* ((string "fn main() { let s = 1;}")
          (buf (rustic-test-count-error-helper-new string))


### PR DESCRIPTION
In order to maintain backwards compatibility, keep value empty.

Should close https://github.com/brotzeit/rustic/issues/386.