### PR TITLE
Add detached file support via eglot and rust-analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,18 @@ you might have to additionally use:
 
 You'll have to have `rust-analyzer` already installed on the target machine.
 
+### Detached file
+
+This is an early experimental feature, and is disabled by default.
+
+Source files not belonging to any crate, or _detached_ source files,
+are supported by rust-analyzer, and this feature can be enabled via
+`rustic-enable-detached-file-support`. (Currently, only eglot is
+supported.)
+
+**Caveat**: Due to some current limitations, you should avoid open a
+detached file in a large directory with this feature enabled.
+
 ## Cargo
 
 Since the cargo commands also use the derived compilation mode, you can use

--- a/README.md
+++ b/README.md
@@ -425,8 +425,8 @@ are supported by rust-analyzer, and this feature can be enabled via
 `rustic-enable-detached-file-support`. (Currently, only eglot is
 supported.)
 
-**Caveat**: Due to some current limitations, you should avoid open a
-detached file in a large directory with this feature enabled.
+**Caveat**: Due to some current limitations, you should avoid opening
+a detached file in a large directory with this feature enabled.
 
 ## Cargo
 

--- a/rustic-lsp.el
+++ b/rustic-lsp.el
@@ -145,8 +145,8 @@ with `lsp-rust-switch-server'."
   (cl-defmethod eglot-initialization-options ((server eglot-rust-analyzer))
     "Pass `detachedFiles' when `rustic-enable-detached-file-support' is non-`nil'."
     (if (or (null rustic-enable-detached-file-support)
-            (rustic-buffer-crate t)
-            (null buffer-file-name))
+            (null buffer-file-name)
+            (rustic-buffer-crate t))
         eglot--{}
       (list :detachedFiles
             (vector (file-local-name (file-truename buffer-file-name))))))


### PR DESCRIPTION
Provide rust-analyzer-specific initialization option `detachedFiles` when a file is not in a crate.

Closes #391 