### PR TITLE
Ignore stderr on cargo cmd for workspace detection

### DIFF
--- a/rustic.el
+++ b/rustic.el
@@ -67,7 +67,7 @@
   (if rustic--buffer-workspace
       rustic--buffer-workspace
     (with-temp-buffer
-      (let ((ret (call-process (rustic-cargo-bin) nil t nil "locate-project" "--workspace")))
+      (let ((ret (call-process (rustic-cargo-bin) nil (list (current-buffer) nil) nil "locate-project" "--workspace")))
         (when (and (/= ret 0) (not nodefault))
           (error "`cargo locate-project' returned %s status: %s" ret (buffer-string)))
         (goto-char 0)


### PR DESCRIPTION
If the workspace is not in a pristine state the command
prepends the stdout with warnings on stderr like
```
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   blah
workspace: higher/than/blah
```
This triggered a `JSON readtable error` mentionning `119` which
is the ascii code for `w`

Ignoring stderr output allows to continue with workspace detection
even with warnings