### PR TITLE
Add `cargo login` command

### DIFF
--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -709,5 +709,17 @@ If running with prefix command `C-u', read whole command from minibuffer."
                       (concat (rustic-cargo-bin) " upgrade"))))
       (rustic-run-cargo-command command))))
 
+;;;###autoload
+(defun rustic-cargo-login (token)
+  "Add crates.io API token using `cargo login'.
+
+`TOKEN' the token for interacting with crates.io. Visit [1] for
+        how to get one
+
+[1] https://doc.rust-lang.org/cargo/reference/publishing.html#before-your-first-publish"
+
+  (interactive "sAPI token: ")
+  (shell-command (format "%s login %s" (rustic-cargo-bin) token)))
+
 (provide 'rustic-cargo)
 ;;; rustic-cargo.el ends here

--- a/test/rustic-cargo-test.el
+++ b/test/rustic-cargo-test.el
@@ -253,3 +253,20 @@ fn test() {
     (with-current-buffer (get-buffer rustic-expand-buffer-name)
       (let ((buf-string (buffer-substring-no-properties (point-min) (point-max))))
         (should (string-match "^cargo expand" buf-string))))))
+
+(ert-deftest rustic-cargo-login-test ()
+  (let* ((process-environment (cl-copy-list process-environment))
+         (tempdir (concat (temporary-file-directory) (file-name-as-directory "rustic-cargo-login-test")))
+         (credfile (concat tempdir "credentials")))
+
+    (when (file-exists-p credfile) (delete-file credfile))
+
+    (setenv "CARGO_HOME" tempdir)
+
+    (rustic-cargo-login "test-credentials")
+
+    (with-temp-buffer
+      (find-file credfile)
+      (let ((buf-string (buffer-string)))
+        (message buf-string)
+        (should (string-match "\\\[registry\\\]\ntoken = \"test-credentials\"\n" buf-string))))))


### PR DESCRIPTION
`cargo login <TOKEN>` adds a token for https://crates.io to the local
`$CARGO_HOME/credentials` file. This is then used for `cargo`
commands that somehow interact with crates.io like `cargo publish`.