### PR TITLE
remap recompile keybinding and enable `compilation-start-hook`

### DIFF
--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -89,7 +89,7 @@ stored in this variable.")
 (defvar rustic-cargo-test-mode-map
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map rustic-compilation-mode-map)
-    (define-key map (kbd "g") 'rustic-cargo-test-rerun)
+    (define-key map [remap recompile] 'rustic-cargo-test-rerun)
     map)
   "Local keymap for `rustic-cargo-test-mode' buffers.")
 
@@ -521,7 +521,7 @@ If BIN is not nil, create a binary application, otherwise a library."
 
 (defvar rustic-cargo-run-mode-map
   (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "g") 'rustic-cargo-run-rerun)
+    (define-key map [remap recompile] 'rustic-cargo-run-rerun)
     map)
   "Local keymap for `rustic-cargo-test-mode' buffers.")
 

--- a/rustic-clippy.el
+++ b/rustic-clippy.el
@@ -33,7 +33,7 @@
 
 (defvar rustic-cargo-clippy-mode-map
   (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "g") 'rustic-cargo-clippy-rerun)
+    (define-key map [remap recompile] 'rustic-cargo-clippy-rerun)
     map)
   "Local keymap for `rustic-cargo-clippy-mode' buffers.")
 

--- a/rustic-compile.el
+++ b/rustic-compile.el
@@ -235,6 +235,7 @@ Set environment variables for rust process."
                     #'start-file-process (plist-get args :name)
                     (plist-get args :buffer)
                     (plist-get args :command))))
+      (run-hook-with-args 'compilation-start-hook process)
       (set-process-filter process (plist-get args :filter))
       (set-process-sentinel process (plist-get args :sentinel))
       (set-process-coding-system process 'utf-8-emacs-unix 'utf-8-emacs-unix)

--- a/rustic-compile.el
+++ b/rustic-compile.el
@@ -134,7 +134,7 @@
     (suppress-keymap map t)
     (set-keymap-parent map compilation-mode-map)
     (define-key map "p" 'rustic-popup)
-    (define-key map "g" 'rustic-recompile)
+    (define-key map [remap recompile] 'rustic-recompile)
     map)
   "Keymap for rust compilation log buffers.")
 

--- a/rustic-expand.el
+++ b/rustic-expand.el
@@ -20,7 +20,7 @@
 
 (defvar rustic-cargo-expand-mode-map
   (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "g") 'rustic-cargo-expand-rerun)
+    (define-key map [remap recompile] 'rustic-cargo-expand-rerun)
     map)
   "Local keymap for `rustic-cargo-expand-mode' buffers.")
 


### PR DESCRIPTION
Two changes here:

First is to run `compilation-start-hook` as part of staring a new rustic process. This will let it more closely mirror the functionality of `compile` and work with code that uses that hook (which I often do for setting timers or watchers).

Second we change the hardcoded `g` keybinding for `rustic-recompile` to use the `remap` directive. This will ensure seamless behavior if the user has a different key for recompile (such as when using `evil-mode`).