### PR TITLE
rustic-cargo-comint-run was causing a Lisp error - wrong-type-argumen…

### DIFF
--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -596,9 +596,11 @@ When calling this function from `rustic-popup-mode', always use the value of
 (defun rustic-cargo-run-get-relative-example-name ()
   "Run 'cargo run --example' if current buffer within a 'examples' directory."
   (let* ((buffer-project-root (rustic-buffer-crate))
+         (buffer-path-list (split-string buffer-project-root "\\/"))
+	 (buffer-folder (nth (- (length buffer-path-list) 2) buffer-path-list))     ;; get deepest dir in path
          (relative-filenames
           (if buffer-project-root
-              (split-string (file-relative-name buffer-file-name buffer-project-root) "/") nil)))
+              (split-string (file-relative-name buffer-folder buffer-project-root) "/") nil)))
     (if (and relative-filenames (string= "examples" (car relative-filenames)))
         (let ((size (length relative-filenames)))
           (cond ((eq size 2) (file-name-sans-extension (nth 1 relative-filenames))) ;; examples/single-example1.rs

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -596,11 +596,9 @@ When calling this function from `rustic-popup-mode', always use the value of
 (defun rustic-cargo-run-get-relative-example-name ()
   "Run 'cargo run --example' if current buffer within a 'examples' directory."
   (let* ((buffer-project-root (rustic-buffer-crate))
-         (buffer-path-list (split-string buffer-project-root "\\/"))
-	 (buffer-folder (nth (- (length buffer-path-list) 2) buffer-path-list))     ;; get deepest dir in path
          (relative-filenames
           (if buffer-project-root
-              (split-string (file-relative-name buffer-folder buffer-project-root) "/") nil)))
+              (split-string (file-relative-name buffer-file-name buffer-project-root) "/") nil)))
     (if (and relative-filenames (string= "examples" (car relative-filenames)))
         (let ((size (length relative-filenames)))
           (cond ((eq size 2) (file-name-sans-extension (nth 1 relative-filenames))) ;; examples/single-example1.rs

--- a/rustic-comint.el
+++ b/rustic-comint.el
@@ -54,7 +54,7 @@ If ARG is not nil, use value as argument and store it in `rustic-run-arguments'.
 When calling this function from `rustic-popup-mode', always use the value of
 `rustic-run-arguments'."
   (interactive "P")
-  (let* ((run-args (rustic--get-run-arguments)))
+  (let ((run-args (rustic--get-run-arguments)))
     (pop-to-buffer-same-window
      (get-buffer-create rustic-run-comint-buffer-name))
     (unless (comint-check-proc (current-buffer))

--- a/rustic-comint.el
+++ b/rustic-comint.el
@@ -54,18 +54,19 @@ If ARG is not nil, use value as argument and store it in `rustic-run-arguments'.
 When calling this function from `rustic-popup-mode', always use the value of
 `rustic-run-arguments'."
   (interactive "P")
-  (pop-to-buffer-same-window
-   (get-buffer-create rustic-run-comint-buffer-name))
-  (unless (comint-check-proc (current-buffer))
+  (let* ((run-args (rustic--get-run-arguments)))
+    (pop-to-buffer-same-window
+     (get-buffer-create rustic-run-comint-buffer-name))
+    (unless (comint-check-proc (current-buffer))
     (rustic--cargo-repl-in-buffer
      (current-buffer)
      (concat "run" (cond
                     (arg
                      (setq rustic-run-comint-arguments
                            (read-from-minibuffer "Cargo run arguments: " rustic-run-comint-arguments)))
-                    ((rustic--get-run-arguments))
+                    (run-args)
                     (t ""))))
-    (rustic-cargo-run-comint-mode)))
+    (rustic-cargo-run-comint-mode))))
 
 ;;;###autoload
 (defun rustic-cargo-comint-run-rerun ()


### PR DESCRIPTION
When attempting to run `M-x rustic-cargo-comint-run` for rust code reading from stdin I bumped into this [issue](https://github.com/brotzeit/rustic/issues/173#issuecomment-1179407436). The wrong-type-argument error was captured in this piece of code in the `rustic-cargo-run-get-relative-example-name()` function, the often nil `buffer-file-name` was causing the error.
 ```elisp
(if buffer-project-root
              (split-string (file-relative-name buffer-file-name buffer-project-root) "/") nil)))
```
The correct buffer file name is the name of the directory where the current source file sits (called here `buffer-folder`). I have obtained the name for this directory from `(rustic-buffer-crate)`, in the following form:
```elisp
(let* ((buffer-project-root (rustic-buffer-crate))
         (buffer-path-list (split-string buffer-project-root "\\/"))
	 (buffer-folder (nth (- (length buffer-path-list) 2) buffer-path-list)) 
...
```
the last line is simply fetching the last folder in the path retrieved by `(rustic-buffer-crate)`.
