### PR TITLE
Fix `rustic-format-file` hang on Windows

### DIFF
--- a/rustic-compile.el
+++ b/rustic-compile.el
@@ -238,7 +238,11 @@ Set environment variables for rust process."
       (run-hook-with-args 'compilation-start-hook process)
       (set-process-filter process (plist-get args :filter))
       (set-process-sentinel process (plist-get args :sentinel))
-      (set-process-coding-system process 'utf-8-emacs-unix 'utf-8-emacs-unix)
+      ;; Workaround for rustic-format-file hanging bug on Windows
+      ;; See https://github.com/brotzeit/rustic/issues/423
+      (if (eq system-type 'windows-nt)
+          (set-process-coding-system process default-process-coding-system default-process-coding-system)
+        (set-process-coding-system process 'utf-8-emacs-unix 'utf-8-emacs-unix))
       (process-put process 'command (plist-get args :command))
       (process-put process 'workspace (plist-get args :workspace))
       (process-put process 'file-buffer (plist-get args :file-buffer))


### PR DESCRIPTION
Setting process coding system to `utf-8-emacs-unix` for rustic processes causes issues when reading process signals on non-unix systems. An example of this is #423 . 

This PR sets the coding system of new rustic processes to the value of `default-process-coding-system` which should more reliably ensure that an appropriate coding system is used across environments.