### PR TITLE
uses `process-file` instead of `call-process` to respect remoteness of default directory

### DIFF
--- a/rustic.el
+++ b/rustic.el
@@ -79,7 +79,7 @@
         (setq-local process-environment env)
         ;; Set PATH so we can find cargo.
         (setq-local exec-path path)
-        (let ((ret (call-process (rustic-cargo-bin) nil (list (current-buffer) nil) nil "locate-project" "--workspace")))
+        (let ((ret (process-file (rustic-cargo-bin) nil (list (current-buffer) nil) nil "locate-project" "--workspace")))
           (cond ((and (/= ret 0) nodefault)
                  (error "`cargo locate-project' returned %s status: %s" ret (buffer-string)))
                 ((and (/= ret 0) (not nodefault))


### PR DESCRIPTION
closes #432

perhaps #433 is a more robust solution (that actually resolves for the remote path), but this stopgap solution worked for me because it would just check for cargo on the remote machine first.