### PR TITLE
enable user to configure cargo-build argument when C-u is pressed

### DIFF
--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -635,9 +635,13 @@ in your project like `pwd'"
     (rustic-compilation-start c (append (list :no-default-dir t) args))))
 
 ;;;###autoload
-(defun rustic-cargo-build ()
-  "Run 'cargo build' for the current project."
-  (interactive)
+(defun rustic-cargo-build (arg)
+  "Run 'cargo build' for the current project, allow configuring
+`rustic-cargo-build-arguments' when prefix argument (C-u) is enabled."
+  (interactive "P")
+  (when arg
+    (setq rustic-cargo-build-arguments
+          (read-string "Configure cargo build arguments: " "")))
   (rustic-run-cargo-command `(,(rustic-cargo-bin)
                               ,rustic-cargo-build-exec-command
                               ,@(split-string rustic-cargo-build-arguments))


### PR DESCRIPTION
Hi,

I created a small PR that allows users to configure `rustic-cargo-build-arguments` when running `cargo-build` by pressing the prefix argument key `C-u`.

Can you review and consider merging it?

Thanks!