### PR TITLE
make the prefix argument of cargo-build optional

### DIFF
--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -635,7 +635,7 @@ in your project like `pwd'"
     (rustic-compilation-start c (append (list :no-default-dir t) args))))
 
 ;;;###autoload
-(defun rustic-cargo-build (arg)
+(defun rustic-cargo-build (&optional arg)
   "Run 'cargo build' for the current project, allow configuring
 `rustic-cargo-build-arguments' when prefix argument (C-u) is enabled."
   (interactive "P")


### PR DESCRIPTION
Hi,

I just received a failed CIL build, not sure if that was because of my commit.

But I added a small fix to make the argument of `rustic-cargo-build` optional.
Maybe it can help to resolve the failed CI.