### PR TITLE
change cargo install default arguments

### DIFF
--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -65,7 +65,7 @@ If nil then the project is simply created."
   :type 'string
   :group 'rustic-cargo)
 
-(defcustom rustic-cargo-default-install-arguments '("--path" ".")
+(defcustom rustic-cargo-default-install-arguments '("--path" "." "--locked")
   "Default arguments when running 'cargo install'."
   :type '(list string)
   :group 'rustic-cargo)


### PR DESCRIPTION
The --locked flag can be used to force Cargo to use the packaged
Cargo.lock file if it is available.

Apart from being faster in the general cases, this is what most user
will expect to use. Also this guarantees a better reproducibile
builds.