### PR TITLE
allow config rustic-cargo-check-arguments on C-u

### DIFF
--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -641,7 +641,7 @@ in your project like `pwd'"
   (interactive "P")
   (when arg
     (setq rustic-cargo-build-arguments
-          (read-string "Configure cargo build arguments: " "")))
+          (read-string "Cargo build arguments: " "")))
   (rustic-run-cargo-command `(,(rustic-cargo-bin)
                               ,rustic-cargo-build-exec-command
                               ,@(split-string rustic-cargo-build-arguments))
@@ -670,9 +670,13 @@ When calling this function from `rustic-popup-mode', always use the value of
                          (t rustic-clean-arguments)))))))
 
 ;;;###autoload
-(defun rustic-cargo-check ()
-  "Run 'cargo check' for the current project."
-  (interactive)
+(defun rustic-cargo-check (&optional arg)
+  "Run 'cargo check' for the current project, allow configuring
+`rustic-cargo-check-arguments' when prefix argument (C-u) is enabled."
+  (interactive "p")
+  (when arg
+    (setq rustic-cargo-check-arguments
+          (read-string "Cargo check arguments: " "")))
   (rustic-run-cargo-command `(,(rustic-cargo-bin)
                               ,rustic-cargo-check-exec-command
                               ,@(split-string rustic-cargo-check-arguments))))

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -673,7 +673,7 @@ When calling this function from `rustic-popup-mode', always use the value of
 (defun rustic-cargo-check (&optional arg)
   "Run 'cargo check' for the current project, allow configuring
 `rustic-cargo-check-arguments' when prefix argument (C-u) is enabled."
-  (interactive "p")
+  (interactive "P")
   (when arg
     (setq rustic-cargo-check-arguments
           (read-string "Cargo check arguments: " "")))


### PR DESCRIPTION
Hi, 

This is a simple PR to allow users to configure a custom `rustic-cargo-check-arguments` on when pressing `C-u`.

Can you review and consider merging it?

Thanks!