### PR TITLE
add bound check to `rustic-cargo-auto-add-missing-dependencies`

### DIFF
--- a/rustic.el
+++ b/rustic.el
@@ -152,7 +152,7 @@ this variable."
 \\{rustic-mode-map}"
   :group 'rustic
 
-  (when rustic-cargo-auto-add-missing-dependencies
+  (when (bound-and-true-p rustic-cargo-auto-add-missing-dependencies)
    (add-hook 'lsp-after-diagnostics-hook 'rustic-cargo-add-missing-dependencies-hook nil t)))
 
 ;;;###autoload


### PR DESCRIPTION
Hi :wave: When I set `rustic-load-optional-libraries` to `nil`, I got this error on M-x `rustic-mode`:

> Symbol's value as variable is void: rustic-cargo-auto-add-missing-dependencies

I think it's because `rustic-cargo.el` is not loaded and their custom variables are not set.

This PR fixes it by adding `bound-and-true-p` check.
