### PR TITLE
consider buffer-save-without-query in rustic-save-some-buffers

### DIFF
--- a/rustic-compile.el
+++ b/rustic-compile.el
@@ -402,7 +402,7 @@ Return non-nil if there was a live process."
     (when procs
       (rustic-process-kill-p (car procs)))
     (unless nosave
-      (rustic-save-some-buffers))
+      (rustic-save-some-buffers t))
     procs))
 
 (defun rustic-process-kill-p (proc &optional no-error)
@@ -420,7 +420,7 @@ If NO-ERROR is t, don't throw error if user chooses not to kill running process.
     (unless no-error
       (error "Cannot have two rust processes at once"))))
 
-(defun rustic-save-some-buffers ()
+(defun rustic-save-some-buffers (&optional compile-p)
   "Unlike `save-some-buffers', only consider project related files.
 
 The variable `compilation-ask-about-save' can be used for customization and
@@ -442,14 +442,16 @@ buffers are formatted after saving if turned on by `rustic-format-trigger'."
             (let ((rustic-format-trigger nil)
                   (rustic-format-on-save nil))
               (setq saved-p
-                    (if (not compilation-ask-about-save)
+                    (if (if compile-p
+                            (not compilation-ask-about-save)
+                          buffer-save-without-query)
                         (progn (save-buffer) t)
                       (if (yes-or-no-p (format "Save file %s ? "
                                                (buffer-file-name buffer)))
                           (progn (save-buffer) t)
                         nil))))
             (when (and saved-p
-                       (eq major-mode 'rustic-mode)
+                       (derived-mode-p 'rustic-mode)
                        (fboundp 'rustic-maybe-format-after-save))
               (rustic-maybe-format-after-save buffer))))))))
 

--- a/test/rustic-compile-test.el
+++ b/test/rustic-compile-test.el
@@ -28,7 +28,8 @@
          (string "fn main()      {}")
          (formatted-string "fn main() {}\n")
          (dir (rustic-babel-generate-project t))
-         (rustic-format-trigger 'on-save))
+         (rustic-format-trigger 'on-save)
+         (compilation-ask-about-save nil))
     (let* ((default-directory dir)
            (src (concat dir "/src"))
            (file1 (expand-file-name "main.rs" src))
@@ -40,7 +41,7 @@
       (with-current-buffer buffer2
         (write-file file2)
         (insert string))
-      (rustic-save-some-buffers)
+      (rustic-save-some-buffers t)
       (sit-for 1)
       (with-current-buffer buffer1
         (should (string= (buffer-string) formatted-string)))
@@ -49,7 +50,6 @@
     (kill-buffer buffer1)
     (kill-buffer buffer2)))
 
-;; test if `compilation-ask-about-save' overrides `buffer-save-without-query'
 (ert-deftest rustic-test-save-some-buffers-compilation-ask-about-save ()
 (let* ((buffer1 (get-buffer-create "b1"))
          (buffer2 (get-buffer-create "b2"))
@@ -58,7 +58,7 @@
          (dir (rustic-babel-generate-project t))
          (rustic-format-trigger 'on-save)
          (buffer-save-without-query nil)
-         (compilation-ask-about-save t))
+         (compilation-ask-about-save nil))
     (let* ((default-directory dir)
            (src (concat dir "/src"))
            (file1 (expand-file-name "main.rs" src))
@@ -70,7 +70,7 @@
       (with-current-buffer buffer2
         (write-file file2)
         (insert string))
-      (rustic-save-some-buffers)
+      (rustic-save-some-buffers t)
       (sit-for 1)
       (with-current-buffer buffer1
         (should (string= (buffer-string) formatted-string)))


### PR DESCRIPTION
when called from advice around save-some-buffers, but ignore it when running rustic complile commands

close #424