### PR TITLE
rustic-save-some-buffers-advice: respect the `pred' argument of `save-some-buffers'

### DIFF
--- a/rustic-rustfmt.el
+++ b/rustic-rustfmt.el
@@ -458,7 +458,10 @@ non-nil."
 (defun rustic-save-some-buffers-advice (orig-fun &rest args)
   "Use `rustic-save-some-buffers' instead when called in rust project.
 Otherwise turn off rustic format functionality and run `save-some-buffers'."
-  (if (rustic-buffer-crate t)
+  (if (and
+       (rustic-buffer-crate t)
+       (let ((pred (nth 1 args)))
+         (if (functionp pred) (funcall pred) t)))
       (rustic-save-some-buffers)
     (let ((rustic-format-trigger nil)
           (rustic-format-on-save nil))


### PR DESCRIPTION
In some situation like `org-save-all-org-buffers', one might do not want to save the rust  buffer