### PR TITLE
use rustic-test-arguments by default

### DIFF
--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -119,7 +119,7 @@ Currently only working with lsp-mode."
 (defvar rustic-test-buffer-name "*cargo-test*"
   "Buffer name for test buffers.")
 
-(defvar rustic-test-arguments ""
+(defvar rustic-test-arguments rustic-default-test-arguments
   "Holds arguments for 'cargo test', similar to `compilation-arguments`.
 Tests that are executed by `rustic-cargo-current-test' will also be
 stored in this variable.")
@@ -177,7 +177,7 @@ When calling this function from `rustic-popup-mode', always use the value of
               rustic-test-arguments
             rustic-default-test-arguments))
          (t
-          rustic-default-test-arguments))))
+          rustic-test-arguments))))
 
 ;;;###autoload
 (defun rustic-cargo-test-rerun ()


### PR DESCRIPTION
Hi,

Currently, the command `rustic-cargo-test` always runs with the default argument `rustic-default-test-arguments`. Users can set up a custom argument using `C-u`, but this is only applicable for the current run, and next time, users need to run `C-u` again to update the argument.

I fixed this issue by enabling `rustic-cargo-test` to run with `rustic-test-arguments`, which is initialized by `rustic-default-test-arguments`, and is only needed to be updated by users once using `C-u`.

Can you review and merge this PR if possible?

Thanks!