### PR TITLE
Revert "Fix `rustic-format-file` hang on Windows"

### DIFF
--- a/rustic-compile.el
+++ b/rustic-compile.el
@@ -238,11 +238,7 @@ Set environment variables for rust process."
       (run-hook-with-args 'compilation-start-hook process)
       (set-process-filter process (plist-get args :filter))
       (set-process-sentinel process (plist-get args :sentinel))
-      ;; Workaround for rustic-format-file hanging bug on Windows
-      ;; See https://github.com/brotzeit/rustic/issues/423
-      (if (eq system-type 'windows-nt)
-          (set-process-coding-system process default-process-coding-system default-process-coding-system)
-        (set-process-coding-system process 'utf-8-emacs-unix 'utf-8-emacs-unix))
+      (set-process-coding-system process 'utf-8-emacs-unix 'utf-8-emacs-unix)
       (process-put process 'command (plist-get args :command))
       (process-put process 'workspace (plist-get args :workspace))
       (process-put process 'file-buffer (plist-get args :file-buffer))


### PR DESCRIPTION
Reverts brotzeit/rustic#426

Given that #426 is now known to cause issues ( reported in [issue 423](https://github.com/brotzeit/rustic/issues/423#issuecomment-1302800867) ) without a definite understanding of how this 'fix' worked in the first place reverting it is the best course. If a true fix is found after more investigation I'll be sure to add another PR for that.