### PR TITLE
Use `default-directory` in popup buffer instead of `buffer-file-name`

### DIFF
--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -634,12 +634,13 @@ When calling this function from `rustic-popup-mode', always use the value of
   (let* ((buffer-project-root (rustic-buffer-crate))
          (relative-filenames
           (if buffer-project-root
-              (split-string (file-relative-name buffer-file-name buffer-project-root) "/") nil)))
+              (split-string (file-relative-name default-directory buffer-project-root) "/") nil)))
     (if (and relative-filenames (string= "examples" (car relative-filenames)))
         (let ((size (length relative-filenames)))
           (cond ((eq size 2) (file-name-sans-extension (nth 1 relative-filenames))) ;; examples/single-example1.rs
                 ((> size 2) (car (nthcdr (- size 2) relative-filenames)))           ;; examples/example2/main.rs
-                (t nil))) nil)))
+                (t nil)))
+      nil)))
 
 ;;;###autoload
 (defun rustic-run-shell-command (&optional arg)


### PR DESCRIPTION
`buffer-file-name` is not defined in the rustic popup buffer (which has focus after it is popped up)
since it isn't associated with a buffer, but `default-directory` does.

Since `rustic-cargo-run-get-relative-example-name` is only looking at the first component of the
relative path and checking to see if it is in the examples directory, the full path to the file
buffer does not matter.

fixes #392