### PR TITLE
Fixes edge case of running examples and plain binary

### DIFF
--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -615,7 +615,7 @@ When calling this function from `rustic-popup-mode', always use the value of
          (rustic-cargo-use-last-stored-arguments
           rustic-run-arguments)
          ((rustic--get-run-arguments))
-         (t ""))))
+         (t rustic-run-arguments))))
 
 ;;;###autoload
 (defun rustic-cargo-run-rerun ()
@@ -625,16 +625,19 @@ When calling this function from `rustic-popup-mode', always use the value of
 
 (defun rustic--get-run-arguments ()
   "Helper utility for getting arguments related to 'examples' directory."
-  (if (rustic-cargo-run-get-relative-example-name)
-      (concat "--example " (rustic-cargo-run-get-relative-example-name))
-    (car compile-history)))
+  (let ((example-name (rustic-cargo-run-get-relative-example-name)))
+    (when example-name
+      (concat "--example " example-name))))
 
 (defun rustic-cargo-run-get-relative-example-name ()
   "Run 'cargo run --example' if current buffer within a 'examples' directory."
   (let* ((buffer-project-root (rustic-buffer-crate))
+         (current-filename (if buffer-file-name
+                               buffer-file-name
+                             rustic--popup-rust-src-name))
          (relative-filenames
           (if buffer-project-root
-              (split-string (file-relative-name default-directory buffer-project-root) "/") nil)))
+              (split-string (file-relative-name current-filename buffer-project-root) "/") nil)))
     (if (and relative-filenames (string= "examples" (car relative-filenames)))
         (let ((size (length relative-filenames)))
           (cond ((eq size 2) (file-name-sans-extension (nth 1 relative-filenames))) ;; examples/single-example1.rs

--- a/rustic-popup.el
+++ b/rustic-popup.el
@@ -50,6 +50,9 @@ The first element of each list contains a command's binding."
 (defvar rustic-popup-buffer-name "rustic-popup-buffer"
   "Buffer name for rustic popup buffers.")
 
+(defvar rustic--popup-rust-src-name nil
+  "Rust source code file name from which rustic-popup was invoked.")
+
 (defvar rustic-popup-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map [remap self-insert-command] 'rustic-popup-invoke-popup-action)
@@ -111,6 +114,7 @@ The first element of each list contains a command's binding."
   "Setup popup.
 If directory is not in a rust project call `read-directory-name'."
   (interactive "P")
+  (setq rustic--popup-rust-src-name buffer-file-name)
   (let ((func (lambda ()
                 (let ((buf (get-buffer-create rustic-popup-buffer-name))
                       (win (split-window-below))


### PR DESCRIPTION
This also makes sure that cargo-run works in both the workflows: with and without popup/ in plain binary crate as well as examples.

Notes about changes:

- When we invoke rustic popup, the buffer-file-name becomes nil which caues it to break when running examples. So we create a new variable to tracke the source file name now.
- We optimize rustic--get-run-arguments to avoid calling to rustic-cargo-run-get-relative-example-name
- We use rustic-run-arguments as last resort. It's a good fallback to have IMO and it's default value is nil anyway.