### PR TITLE
Improve lsp-mode language server client interaction with cargo fmt

### DIFF
--- a/rustic-rustfmt.el
+++ b/rustic-rustfmt.el
@@ -275,7 +275,7 @@ and it's `cdr' is a list of arguments."
                           (funcall rustic-list-project-buffers-function))))
             (dolist (b buffers)
               (with-current-buffer b
-                (revert-buffer t t)))))
+                (revert-buffer t t t)))))
         (kill-buffer proc-buffer)
         (message "Workspace formatted with cargo-fmt.")))))
 

--- a/rustic-rustfmt.el
+++ b/rustic-rustfmt.el
@@ -228,7 +228,7 @@ and it's `cdr' is a list of arguments."
         (if (string-match-p "^finished" output)
             (and
              (with-current-buffer next-error-last-buffer
-               (revert-buffer t t))
+               (revert-buffer t t t))
              (kill-buffer proc-buffer))
           (sit-for 0.1)
           (with-current-buffer next-error-last-buffer
@@ -313,7 +313,7 @@ This operation requires a nightly version of rustfmt.
                                ;; turn off mark after region was formatted
                                ;; successfully
                                (setq mark-active nil)
-                               (revert-buffer t t))
+                               (revert-buffer t t t))
                              (kill-buffer proc-buffer))))))
            (command (append (list (rustic-cargo-bin) "+nightly" "fmt" "--")
                             (rustic-compute-rustfmt-file-lines-args file


### PR DESCRIPTION
Currently, when you invoke rustic-cargo-fmt it takes a quite a bit of time because lsp-mode's rust analyzer connection disconnects and connects with each buffers that are opened in the Emacs buffer. Infact, if you visit your Messages buffer, you would be able to see the logs:

LSP::disconnected
LSP::connected with rust-analyzer

While it is a minor inconvenince for simple projects, for projects with huge number of files - it's causes a big delay.

Looking at the lsp-mode's code, this is the reason:

- When a major mode changes, the lsp-mode disconnects - https://github.com/emacs-lsp/lsp-mode/blob/a2353d0bee8465ce87f7cef1b2ee9b285cb865e2/lsp-mode.el#L4017

And the reason it is getting disconnected is, that rustic-cargo-fmt function doesn't preserve major mode when it is refreshes the text from the content present on the disk.

The fix for it is simple, it makes sure that we don't alter the file modes.