### PR TITLE
Improve expand macro and LSP integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ top of the sideline.
 ##### Macro expansion
 
 `lsp-rust-analyzer-expand-macro` expand macro call at point
-recursively
+recursively.
 
 The results are formatted and highlighted by default, but you can use
 your own function by customizing

--- a/rustic-lsp.el
+++ b/rustic-lsp.el
@@ -167,22 +167,15 @@ with `lsp-rust-switch-server'."
 
 ;;;###autoload
 (defun rustic-analyzer-macro-expand (result)
-  "Default method for displaying macro expansion results."
-  (interactive)
+  "Default method for displaying macro expansion RESULT ."
   (let* ((root (lsp-workspace-root default-directory))
          (buf (get-buffer-create
                (format "*rust-analyzer macro expansion %s*" root))))
     (with-current-buffer buf
       (let ((inhibit-read-only t))
         (erase-buffer)
-        ;; wrap expanded macro in a main function so we can run rustfmt
-        (insert "fn main() {")
-        ;; rustfmt complains about $s
-        (insert (replace-regexp-in-string "\\$" "" result))
-        (insert "}")
-        (rustic-macro-expansion-mode)
-
-        (rustic-format-macro-buffer)))
+        (insert result)
+        (rustic-macro-expansion-mode)))
     (display-buffer buf)))
 
 ;;; _

--- a/rustic-rustfmt.el
+++ b/rustic-rustfmt.el
@@ -198,28 +198,6 @@ and it's `cdr' is a list of arguments."
                 (goto-char (point-min)))))
           (message warnings))))))
 
-(defun rustic-format-macro-sentinel (proc output)
-  "Format buffer and remove decorations that we create for rustfmt"
-  (rustic-format-sentinel proc output)
-  (with-current-buffer next-error-last-buffer
-    (save-excursion
-      (read-only-mode -1)
-      ;; remove fn __main() {
-      (goto-char (point-min))
-      (delete-region (point-min) (line-end-position))
-      (delete-blank-lines)
-      (goto-char (point-max))
-      ;; remove } from fn __main()
-      (forward-line -1)
-      (delete-region (line-beginning-position) (point-max))
-      ;; reindent buffer to left
-      (indent-region (point-min) (point-max))
-      (goto-char (point-max))
-      ;; clean blanked line
-      ;; (delete-blank-lines)
-      (delete-trailing-whitespace (point-min) (point-max)))))
-
-
 (defun rustic-format-file-sentinel (proc output)
   "Sentinel for rustfmt processes when formatting a file."
   (ignore-errors
@@ -337,17 +315,6 @@ This operation requires a nightly version of rustfmt.
     (rustic-format-start-process 'rustic-format-sentinel
                                  :buffer (current-buffer)
                                  :stdin (buffer-string))))
-
-(defun rustic-format-macro-buffer ()
-  "Format the current buffer using rustfmt, and theh remove first and last lines."
-  (interactive)
-  (unless (or (eq major-mode 'rustic-mode)
-              (eq major-mode 'rustic-macro-expansion-mode))
-    (error "Not a rustic-mode buffer."))
-  (rustic-compilation-process-live t)
-  (rustic-format-start-process 'rustic-format-macro-sentinel
-                               :buffer (current-buffer)
-                               :stdin (buffer-string)))
 
 ;;;###autoload
 (defun rustic-format-file (&optional file)


### PR DESCRIPTION
We do the following changes:

- Do not try to format the macro as the response from the language server (rust-analzyer) comes in the formatted fashion: https://github.com/rust-lang/rust-analyzer/pull/12014
- Avoid the extra wrapping of main to please rustfmt as it's not required anymore.
- Make rustic-analyzer-macro-expand non interactive as it's not meant to be called interactively. It's called from the lsp-mode's rust client integration.

Ultimately this fixes #473 