### PR TITLE
Fix org-babel workflow when auto wrapping main function

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ of rustic, however can be considered light-weight compared to some rustic's
 functionality.
 
 The shared functions and options exist as aliases in the rust-mode and
-rustic namespace for backwards compatability reasons(rustic has been a fork).
+rustic namespace for backwards compatibility reasons(rustic has been a fork).
 
 ## Known issues
 

--- a/test/rustic-babel-test.el
+++ b/test/rustic-babel-test.el
@@ -116,6 +116,7 @@
 (ert-deftest rustic-test-babel-format ()
   (let* ((string "fn main()      {}")
          (formatted-string "  fn main() {}\n")
+         (rustic-babel-auto-wrap-main nil)
          (buf (rustic-test-get-babel-block string)))
     (with-current-buffer buf
       (rustic-test-babel-execute-block buf)


### PR DESCRIPTION
This bug is easily reproducible when you use try something like this:

```
let x = [1,2,3,4,5,6];
println!("{x:?}");
```

And then try executing it. While you will get the result properly, you could see in the Messages buffer that that would be some errors related to compilation buffer.

And the reason is this: It tries to do rustfmt on the babel block and fails. In this fix, I just disable doing rustfmt when we have enabled automatic wrapping or when we instruct it to wrap the main function.

Another alternative fix could be do rustfmt on the wrapped main function and the remove the wrapped main function and render it again on the babel blocks. But IMO, that's going to be very fragile.