### PR TITLE
Make envrc mode work

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@
             - [:main](#main)
             - [:include](#include)
             - [:use](#use)
+    - [Envrc](#envrc)
     - [Spinner](#spinner)
     - [rust docs in org-mode](#rust-docs-in-org-mode)
         - [Prerequisites](#prerequisites)
@@ -822,6 +823,14 @@ fn main() {
 #+RESULTS:
 : "mymodule function called"
 ```
+
+
+## envrc
+
+To load your Rust toolchain via [envrc](https://github.com/purcell/envrc), ensure that
+the [inheritenv](https://github.com/purcell/inheritenv) package is available before
+loading rustic, so that auxiliary rustic buffers acquire the correct environment to find
+the toolchain.
 
 ## Spinner
 

--- a/rustic-comint.el
+++ b/rustic-comint.el
@@ -54,29 +54,31 @@ If ARG is not nil, use value as argument and store it in `rustic-run-arguments'.
 When calling this function from `rustic-popup-mode', always use the value of
 `rustic-run-arguments'."
   (interactive "P")
-  (let ((run-args (rustic--get-run-arguments)))
-    (pop-to-buffer-same-window
-     (get-buffer-create rustic-run-comint-buffer-name))
-    (unless (comint-check-proc (current-buffer))
-    (rustic--cargo-repl-in-buffer
-     (current-buffer)
-     (concat "run" (cond
-                    (arg
-                     (setq rustic-run-comint-arguments
-                           (read-from-minibuffer "Cargo run arguments: " rustic-run-comint-arguments)))
-                    (run-args)
-                    (t ""))))
-    (rustic-cargo-run-comint-mode))))
+  (rustic--inheritenv
+   (let ((run-args (rustic--get-run-arguments)))
+     (pop-to-buffer-same-window
+      (get-buffer-create rustic-run-comint-buffer-name))
+     (unless (comint-check-proc (current-buffer))
+       (rustic--cargo-repl-in-buffer
+        (current-buffer)
+        (concat "run" (cond
+                       (arg
+                        (setq rustic-run-comint-arguments
+                              (read-from-minibuffer "Cargo run arguments: " rustic-run-comint-arguments)))
+                       (run-args)
+                       (t ""))))
+       (rustic-cargo-run-comint-mode)))))
 
 ;;;###autoload
 (defun rustic-cargo-comint-run-rerun ()
   "Run `cargo run' with `rustic-run-comint-arguments'."
   (interactive)
-  (pop-to-buffer-same-window
-   (get-buffer-create rustic-run-comint-buffer-name))
-  (rustic--cargo-repl-in-buffer
-   (current-buffer)
-   (concat "run" rustic-run-comint-arguments)))
+  (rustic--inheritenv
+   (pop-to-buffer-same-window
+    (get-buffer-create rustic-run-comint-buffer-name))
+   (rustic--cargo-repl-in-buffer
+    (current-buffer)
+    (concat "run" rustic-run-comint-arguments))))
 
 (defun rustic--cargo-repl-in-buffer (buffer run-args)
   "Make Cargo comint Repl in BUFFER.

--- a/rustic-compile.el
+++ b/rustic-compile.el
@@ -283,29 +283,30 @@ ARGS is a plist that affects how the process is run.
 - `:mode' mode for process buffer
 - `:directory' set `default-directory'
 - `:sentinel' process sentinel"
-  (let* ((buf (get-buffer-create
-               (or (plist-get args :buffer) rustic-compilation-buffer-name)))
-         (process (or (plist-get args :process) rustic-compilation-process-name))
-         (mode (or (plist-get args :mode) 'rustic-compilation-mode))
-         (directory (or (plist-get args :directory) (funcall rustic-compile-directory-method)))
-         (workspace (rustic-buffer-workspace (plist-get args :no-default-dir)))
-         (sentinel (or (plist-get args :sentinel) #'rustic-compilation-sentinel))
-         (file-buffer (current-buffer)))
-    (rustic-compilation-setup-buffer buf directory mode)
-    (setq next-error-last-buffer buf)
-    (unless (plist-get args :no-display)
-      (funcall rustic-compile-display-method buf))
-    (with-current-buffer buf
-      (let ((inhibit-read-only t))
-        (insert (format "%s \n" (s-join " "  command))))
-      (rustic-make-process :name process
-                           :buffer buf
-                           :command command
-                           :file-buffer file-buffer
-                           :filter #'rustic-compilation-filter
-                           :sentinel sentinel
-                           :workspace workspace
-                           :file-handler t))))
+  (rustic--inheritenv
+   (let* ((buf (get-buffer-create
+                (or (plist-get args :buffer) rustic-compilation-buffer-name)))
+          (process (or (plist-get args :process) rustic-compilation-process-name))
+          (mode (or (plist-get args :mode) 'rustic-compilation-mode))
+          (directory (or (plist-get args :directory) (funcall rustic-compile-directory-method)))
+          (workspace (rustic-buffer-workspace (plist-get args :no-default-dir)))
+          (sentinel (or (plist-get args :sentinel) #'rustic-compilation-sentinel))
+          (file-buffer (current-buffer)))
+     (rustic-compilation-setup-buffer buf directory mode)
+     (setq next-error-last-buffer buf)
+     (unless (plist-get args :no-display)
+       (funcall rustic-compile-display-method buf))
+     (with-current-buffer buf
+       (let ((inhibit-read-only t))
+         (insert (format "%s \n" (s-join " "  command))))
+       (rustic-make-process :name process
+                            :buffer buf
+                            :command command
+                            :file-buffer file-buffer
+                            :filter #'rustic-compilation-filter
+                            :sentinel sentinel
+                            :workspace workspace
+                            :file-handler t)))))
 
 (defun rustic-compilation-filter (proc string)
   "Insert the text emitted by PROC.
@@ -515,26 +516,27 @@ buffer."
 
 (defun rustic-explain-error (button)
   "Open buffer with explanation for error at point."
-  (let* ((button-string (button-label button))
-         (errno (progn (string-match "E[0-9]+" button-string)
-                       (match-string 0 button-string)))
-         (buf (get-buffer-create "*rust errno*"))
-         (inhibit-read-only t))
-    (with-current-buffer buf
-      (erase-buffer)
-      (insert (shell-command-to-string
-               (concat "rustc --explain=" errno)))
-      (markdown-view-mode)
-      (setq
-       header-line-format
-       (concat (propertize " " 'display
-                           `(space :align-to (- right-fringe ,(1+ (length errno)))))
-               (propertize errno 'face 'rustic-errno-face)))
-      (setq-local markdown-fontify-code-blocks-natively t)
-      (setq-local markdown-fontify-code-block-default-mode 'rustic-mode)
-      (markdown-toggle-markup-hiding 1)
-      (goto-char (point-min)))
-    (pop-to-buffer buf)))
+  (rustic--inheritenv
+   (let* ((button-string (button-label button))
+          (errno (progn (string-match "E[0-9]+" button-string)
+                        (match-string 0 button-string)))
+          (buf (get-buffer-create "*rust errno*"))
+          (inhibit-read-only t))
+     (with-current-buffer buf
+       (erase-buffer)
+       (insert (shell-command-to-string
+                (concat "rustc --explain=" errno)))
+       (markdown-view-mode)
+       (setq
+        header-line-format
+        (concat (propertize " " 'display
+                            `(space :align-to (- right-fringe ,(1+ (length errno)))))
+                (propertize errno 'face 'rustic-errno-face)))
+       (setq-local markdown-fontify-code-blocks-natively t)
+       (setq-local markdown-fontify-code-block-default-mode 'rustic-mode)
+       (markdown-toggle-markup-hiding 1)
+       (goto-char (point-min)))
+     (pop-to-buffer buf))))
 
 (define-button-type 'rustc-errno
   'action #'rustic-explain-error

--- a/rustic-doc.el
+++ b/rustic-doc.el
@@ -334,20 +334,21 @@ If NOCONFIRM is non-nil, install all dependencies without prompting user."
 If FINISH-FUNC is non-nil, it will be called after PROGRAM has
 exited, with the process object as its only argument.
 Any PROGRAM-ARGS are passed to PROGRAM."
-  (let* ((buf (generate-new-buffer (concat "*" name "*")))
-         (proc (let ((process-connection-type nil))
-                 (apply #'start-process name buf program program-args))))
-    (set-process-sentinel
-     proc (lambda (proc event)
-            (let ((buf (process-buffer proc)))
-              (if (string-match-p (regexp-quote "abnormally") event)
-                  (message "Could not finish process: %s. \
+  (rustic--inheritenv
+   (let* ((buf (generate-new-buffer (concat "*" name "*")))
+          (proc (let ((process-connection-type nil))
+                  (apply #'start-process name buf program program-args))))
+     (set-process-sentinel
+      proc (lambda (proc event)
+             (let ((buf (process-buffer proc)))
+               (if (string-match-p (regexp-quote "abnormally") event)
+                   (message "Could not finish process: %s. \
 See the *Messages* buffer or %s for more info." event (concat "*" name "*"))
-                (when finish-func
-                  (funcall finish-func proc))
-                (when (buffer-live-p buf)
-                  (kill-buffer buf))))))
-    proc))
+                 (when finish-func
+                   (funcall finish-func proc))
+                 (when (buffer-live-p buf)
+                   (kill-buffer buf))))))
+     proc)))
 
 
 

--- a/rustic-flycheck.el
+++ b/rustic-flycheck.el
@@ -44,7 +44,7 @@ current workspace, and returns them in a list, or nil if no
 targets could be found."
   (let ((process-output-as-json
          (lambda (program &rest args)
-           (with-temp-buffer
+           (rustic--with-temp-process-buffer
              (let ((code-or-signal (apply 'process-file program nil '(t nil) nil args)))
                (unless (equal code-or-signal 0)
                  ;; Prevent from displaying "JSON readtable error".

--- a/rustic-lsp.el
+++ b/rustic-lsp.el
@@ -66,7 +66,7 @@ in, e.g. your home directory."
            (if (eq client 'eglot)
                (eglot-ensure)
              (rustic-lsp-mode-setup)
-             (lsp)))
+             (lsp-deferred)))
           (t
            (rustic-install-lsp-client-p client)))))
 
@@ -168,15 +168,16 @@ with `lsp-rust-switch-server'."
 ;;;###autoload
 (defun rustic-analyzer-macro-expand (result)
   "Default method for displaying macro expansion RESULT ."
-  (let* ((root (lsp-workspace-root default-directory))
-         (buf (get-buffer-create
-               (format "*rust-analyzer macro expansion %s*" root))))
-    (with-current-buffer buf
-      (let ((inhibit-read-only t))
-        (erase-buffer)
-        (insert result)
-        (rustic-macro-expansion-mode)))
-    (display-buffer buf)))
+  (rustic--inheritenv
+   (let* ((root (lsp-workspace-root default-directory))
+          (buf (get-buffer-create
+                (format "*rust-analyzer macro expansion %s*" root))))
+     (with-current-buffer buf
+       (let ((inhibit-read-only t))
+         (erase-buffer)
+         (insert result)
+         (rustic-macro-expansion-mode)))
+     (display-buffer buf))))
 
 ;;; _
 (provide 'rustic-lsp)

--- a/rustic-popup.el
+++ b/rustic-popup.el
@@ -114,21 +114,22 @@ The first element of each list contains a command's binding."
   "Setup popup.
 If directory is not in a rust project call `read-directory-name'."
   (interactive "P")
-  (setq rustic--popup-rust-src-name buffer-file-name)
-  (let ((func (lambda ()
-                (let ((buf (get-buffer-create rustic-popup-buffer-name))
-                      (win (split-window-below))
-                      (inhibit-read-only t))
-                  (rustic-popup-insert-contents buf)
-                  (set-window-buffer win buf)
-                  (select-window win)
-                  (fit-window-to-buffer)
-                  (set-window-text-height win (+ (window-height) 1))))))
-    (if args
-        (let ((dir (read-directory-name "Rust project:")))
-          (let ((default-directory dir))
-            (funcall func)))
-      (funcall func))))
+  (rustic--inheritenv
+   (setq rustic--popup-rust-src-name buffer-file-name)
+   (let ((func (lambda ()
+                 (let ((buf (get-buffer-create rustic-popup-buffer-name))
+                       (win (split-window-below))
+                       (inhibit-read-only t))
+                   (rustic-popup-insert-contents buf)
+                   (set-window-buffer win buf)
+                   (select-window win)
+                   (fit-window-to-buffer)
+                   (set-window-text-height win (+ (window-height) 1))))))
+     (if args
+         (let ((dir (read-directory-name "Rust project:")))
+           (let ((default-directory dir))
+             (funcall func)))
+       (funcall func)))))
 
 ;;; Interactive
 
@@ -229,14 +230,15 @@ corresponding line."
 
 (defun rustic-popup-setup-help-popup (string)
   "Switch to help buffer."
-  (let ((buf (get-buffer-create rustic-popup-help-buffer-name)))
-    (switch-to-buffer buf)
-    (erase-buffer)
-    (rustic-popup-help-mode)
-    (insert string)
-    (fit-window-to-buffer)
-    (set-window-text-height (selected-window) (+ (window-height) 1))
-    (goto-char (point-min))))
+  (rustic--inheritenv
+   (let ((buf (get-buffer-create rustic-popup-help-buffer-name)))
+     (switch-to-buffer buf)
+     (erase-buffer)
+     (rustic-popup-help-mode)
+     (insert string)
+     (fit-window-to-buffer)
+     (set-window-text-height (selected-window) (+ (window-height) 1))
+     (goto-char (point-min)))))
 
 ;;;###autoload
 (defun rustic-popup-kill-help-buffer ()

--- a/rustic-racer.el
+++ b/rustic-racer.el
@@ -131,17 +131,18 @@ COLUMN number."
 
 (defun rustic-racer-help-buf (contents)
   "Create a *Racer Help* buffer with CONTENTS."
-  (let ((buf (get-buffer-create "*Racer Help*"))
-        ;; If the buffer already existed, we need to be able to
-        ;; override `buffer-read-only'.
-        (inhibit-read-only t))
-    (with-current-buffer buf
-      (erase-buffer)
-      (insert contents)
-      (setq buffer-read-only t)
-      (goto-char (point-min))
-      (rustic-racer-help-mode))
-    buf))
+  (rustic--inheritenv
+   (let ((buf (get-buffer-create "*Racer Help*"))
+         ;; If the buffer already existed, we need to be able to
+         ;; override `buffer-read-only'.
+         (inhibit-read-only t))
+     (with-current-buffer buf
+       (erase-buffer)
+       (insert contents)
+       (setq buffer-read-only t)
+       (goto-char (point-min))
+       (rustic-racer-help-mode))
+     buf)))
 
 ;;; Racer
 
@@ -258,7 +259,7 @@ Return a list (exit-code stdout stderr)."
     (let (exit-code stdout stderr)
       ;; Create a temporary buffer for `call-process` to write stdout
       ;; into.
-      (with-temp-buffer
+      (rustic--with-temp-process-buffer
         (setq exit-code
               (apply #'call-process program nil
                      (list (current-buffer) tmp-file-for-stderr)

--- a/rustic-spellcheck.el
+++ b/rustic-spellcheck.el
@@ -42,29 +42,30 @@ ARGS is a plist that affects how the process is run.
 - `:mode' mode for process buffer
 - `:directory' set `default-directory'
 - `:sentinel' process sentinel"
-  (let* ((buf (get-buffer-create
-               (or (plist-get args :buffer) rustic-compilation-buffer-name)))
-         (process (or (plist-get args :process) rustic-compilation-process-name))
-         (mode (or (plist-get args :mode) 'rustic-compilation-mode))
-         (directory (or (plist-get args :directory) (funcall rustic-compile-directory-method)))
-         (workspace (rustic-buffer-workspace (plist-get args :no-default-dir)))
-         (sentinel (or (plist-get args :sentinel) #'rustic-compilation-sentinel))
-         (file-buffer (current-buffer)))
-    (rustic-compilation-setup-buffer buf directory mode)
-    (setq next-error-last-buffer buf)
-    (unless (plist-get args :no-display)
-      (funcall rustic-compile-display-method buf))
-    (with-current-buffer buf
-      (let ((inhibit-read-only t))
-        (insert (format "%s \n" (s-join " "  command))))
-      (rustic-make-process :name process
-                           :buffer buf
-                           :command command
-                           :file-buffer file-buffer
-                           :filter #'rustic-compilation-filter
-                           :sentinel sentinel
-                           :workspace workspace
-                           :file-handler t))))
+  (rustic--inheritenv
+   (let* ((buf (get-buffer-create
+                (or (plist-get args :buffer) rustic-compilation-buffer-name)))
+          (process (or (plist-get args :process) rustic-compilation-process-name))
+          (mode (or (plist-get args :mode) 'rustic-compilation-mode))
+          (directory (or (plist-get args :directory) (funcall rustic-compile-directory-method)))
+          (workspace (rustic-buffer-workspace (plist-get args :no-default-dir)))
+          (sentinel (or (plist-get args :sentinel) #'rustic-compilation-sentinel))
+          (file-buffer (current-buffer)))
+     (rustic-compilation-setup-buffer buf directory mode)
+     (setq next-error-last-buffer buf)
+     (unless (plist-get args :no-display)
+       (funcall rustic-compile-display-method buf))
+     (with-current-buffer buf
+       (let ((inhibit-read-only t))
+         (insert (format "%s \n" (s-join " "  command))))
+       (rustic-make-process :name process
+                            :buffer buf
+                            :command command
+                            :file-buffer file-buffer
+                            :filter #'rustic-compilation-filter
+                            :sentinel sentinel
+                            :workspace workspace
+                            :file-handler t)))))
 
 (define-compilation-mode rustic-cargo-spellcheck-mode "rustic-cargo-spellcheck"
   "Rust spellcheck compilation mode.


### PR DESCRIPTION
Propagate process-environment and exec-path to any auxiliary buffer which is created, so that [envrc](https://github.com/purcell/envrc) mode works.

An example requirement for this is with [Nix development shells via direnv](https://nixos.wiki/wiki/Development_environment_with_nix-shell).  With this, the Rust compiler, rust-analyzer, et al are not on the user's default path, but only on a local path configured by direnv within the project directory.

Two different mechanisms are used to make this work.

1. Code which makes use of `get-buffer-create` or `generate-new-buffer` is wrapped in [inheritenv](https://github.com/purcell/inheritenv)

2. A macro which wraps `with-temp-buffer` is used in place of that, since inheritenv does not handle that case, adapted from https://github.com/magit/magit/pull/4169

Subsequent additions of code which creates such auxiliary buffers should do likewise.

Additionally, LSP mode is started with `lsp-deferred` so that envrc has a chance to configure the path before it is required.

This change is working for me for cargo compilation and LSP mode rust-analyzer.  I am sure I'm not utilising the full surface area of rustic mode, so may have overlooked something.  Feedback welcome.

Fixes #420
