### PR TITLE
[cargo-outdated] Add support for workspaces

### DIFF
--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -404,7 +404,7 @@ Execute process in PATH."
   (interactive)
   (let* ((crate (tabulated-list-get-entry (point)))
          (v (read-from-minibuffer "Update to version: "
-                                  (substring-no-properties (elt crate 2))))
+                                  (substring-no-properties (elt crate 3))))
          (inhibit-read-only t))
     (when v
       (save-excursion

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -290,12 +290,13 @@ When calling this function from `rustic-popup-mode', always use the value of
   "Major mode for viewing outdated crates in the current workspace."
   (setq truncate-lines t)
   (setq tabulated-list-format
-        `[("Name" 25 nil)
+        `[("Name" 25 t)
           ("Project" 10 nil)
           ("Compat" 10 nil)
           ("Latest" 10 nil)
           ("Kind" 10 nil)
-          ("Platform" 0 nil)])
+          ("Workspace" 15 t)
+          ("Platform" 0 t)])
   (setq tabulated-list-padding 2)
   (tabulated-list-init-header))
 
@@ -311,7 +312,6 @@ Execute process in PATH."
     (make-process :name rustic-cargo-outdated-process-name
                   :buffer buf
                   :command `(,(rustic-cargo-bin) "outdated" "--depth" "1")
-                  :filter #'rustic-cargo-outdated-filter
                   :sentinel #'rustic-cargo-outdated-sentinel
                   :file-handler t)
     (with-current-buffer buf
@@ -331,12 +331,6 @@ Execute process in PATH."
   (interactive)
   (rustic-cargo-outdated default-directory))
 
-(defun rustic-cargo-outdated-filter (proc output)
-  "Filter for rustic-cargo-outdated-process."
-  (let ((inhibit-read-only t))
-    (with-current-buffer (process-buffer proc)
-      (insert output))))
-
 (defun rustic-cargo-outdated--skip-to-packages ()
   "Move line forward till we reach the package name."
   (goto-char (point-min))
@@ -353,10 +347,13 @@ Execute process in PATH."
         (exit-status (process-exit-status proc)))
     (if (zerop exit-status)
         (with-current-buffer buf
-          (rustic-cargo-outdated--skip-to-packages)
-          (let ((packages (split-string
-                           (buffer-substring (point) (point-max)) "\n" t)))
-            (erase-buffer)
+          (let ((packages
+                 (mapcar
+                  (lambda (arg)
+                    (split-string arg "================" t "[\n\s]"))
+                  (split-string (buffer-string) "\n\n" t))))
+            (if (= (length packages) 1)
+                (setq packages (list (push "---" (car packages)))))
             (rustic-cargo-outdated-generate-menu packages))
           (pop-to-buffer buf))
       (with-current-buffer buf
@@ -374,13 +371,19 @@ Execute process in PATH."
 
 (defun rustic-cargo-outdated-generate-menu (packages)
   "Re-populate the `tabulated-list-entries' with PACKAGES."
-  (setq tabulated-list-entries
-        (mapcar #'rustic-cargo-outdated-menu-entry packages))
-  (tabulated-list-print t))
+  (let* ((name-with-split-deps
+          (mapcan
+           (lambda (arg0)
+             (nthcdr 2 (mapcar (lambda (arg1) (push (nth 0 arg0) arg1))
+                                (split-string (nth 1 arg0) "\n" t))))
+           packages)))
+    (setq tabulated-list-entries
+           (mapcar #'rustic-cargo-outdated-menu-entry name-with-split-deps))
+     (tabulated-list-print t)))
 
 (defun rustic-cargo-outdated-menu-entry (crate)
   "Return a package entry of CRATE suitable for `tabulated-list-entries'."
-  (let* ((fields (split-string crate "\s\s+" ))
+  (let* ((fields (split-string (cdr crate) "\s+"))
          (name (nth 0 fields))
          (project (nth 1 fields))
          (compat (nth 2 fields)))
@@ -392,6 +395,7 @@ Execute process in PATH."
                     compat)
                  ,(nth 3 fields)
                  ,(nth 4 fields)
+                 ,(car crate)
                  ,(nth 5 fields)])))
 
 ;;;###autoload

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -505,7 +505,7 @@ The CRATE-LINE is a single line from the `rustic-cargo-oudated-buffer-name'"
   (interactive)
   (let ((crates (rustic-cargo--outdated-get-crates (buffer-string))))
     (if crates
-        (let ((msg (format "Upgrade %s ?" (mapconcat #'(lambda (x) (rustic-crate-name x)) crates " "))))
+        (let ((msg (format "Upgrade `%s`? " (mapconcat #'(lambda (x) (rustic-crate-name x)) crates " "))))
           (when (yes-or-no-p msg)
             (rustic-cargo-upgrade-crates crates)))
       (user-error "No operations specified"))))
@@ -526,7 +526,7 @@ The CRATE-LINE is a single line from the `rustic-cargo-oudated-buffer-name'"
   "Upgrade CRATES."
   (let (upgrade)
     (dolist (crate crates)
-      (setq upgrade (concat upgrade (format "%s@%s " (rustic-crate-name crate) (rustic-crate-version crate)))))
+      (setq upgrade (concat upgrade (format "-p %s@%s " (rustic-crate-name crate) (rustic-crate-version crate)))))
     (let ((output (shell-command-to-string (format "cargo upgrade %s" upgrade))))
       (if (string-match "error: no such subcommand:" output)
           (rustic-cargo-install-crate-p "edit")


### PR DESCRIPTION
This MR adds support for running `cargo outdated` in workspaces. In #484 I wrote about potentially using `json` and `vtable` to fix this, but in the end I went up with just aggregating all of the crates in tabulated list mode with a new `Workspace` column showing which crate the dep came from.

## Some screenshots

### Cargo repo with no workspace
![Screenshot from 2023-01-15 13-48-04](https://user-images.githubusercontent.com/8266317/212569018-26056215-ea11-4f2d-a290-244a73547d40.png)

### Cargo repo with workspace
![Screenshot from 2023-01-15 13-49-47](https://user-images.githubusercontent.com/8266317/212569064-a9145fc6-2776-4828-8644-d2602c19d0f7.png)

I also fix some misc issues with the actual upgrading. It looks like `cargo edit` wants a `-p` flag as well?

Closes #484 