### PR TITLE
[cargo outdated] Fix bug when only one crate needs updates

### DIFF
--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -353,7 +353,7 @@ Execute process in PATH."
                   (lambda (arg)
                     (split-string arg "================" t "[\n\s]"))
                   (split-string (buffer-string) "\n\n" t))))
-            (if (= (length packages) 1)
+            (if (and (length packages) (= (length (car packages)) 1))
                 (setq packages (list (push "---" (car packages)))))
             (rustic-cargo-outdated-generate-menu packages))
           (pop-to-buffer buf))


### PR DESCRIPTION
I found a bug when using cargo update that I introduced with my last refactor. The issue is that I was trying to check whether we had a cargo project without a workspace. In this case the goal was to append a dummy name ("---"). Unfortunately, I only checked how many crates in the workspace there where, not whether the first crate doesn't have a name (this only happens in projects without a workspace)