### PR TITLE
Add support for custom rust-analyzer initialization options in eglot

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,30 @@ supported.)
 **Caveat**: Due to some current limitations, you should avoid opening
 a detached file in a large directory with this feature enabled.
 
+### Working with the Rust compiler source
+
+Some projects, such as
+[Clippy](https://github.com/rust-lang/rust-clippy), require that
+`rust-analyzer` can access the compiler source code corresponding to
+the current toolchain. This is done by giving the full path of the
+compiler source into `rust-analyzer` initialization options, or by
+giving it the string "discover" to let it search the sources by
+itself.
+
+In `lsp-mode`, the `lsp-rust-analyzer-rust-source` variable can be set
+to the desired value. In `eglot` mode, a function added to the
+`rustic-eglot-init-options` variable can activate this initialization
+option selectively:
+
+```elisp
+(add-to-list
+  'rustic-eglot-init-options
+  (lambda ()
+    (if (string-prefix-p "/home/john-doe/dev/rust-clippy/"
+                         (rustic-buffer-crate t))
+        '(:rustcSource "discover"))))
+```
+
 ## Cargo
 
 Since the cargo commands also use the derived compilation mode, you can use


### PR DESCRIPTION
Some options can only be passed to rust-analyzer at initialization time, such as `rustc.source`. While lsp supports this use case through the `lsp-rust-analyzer-rustc-source` variable, eglot does not have such support.

This commit adds support for setting more rust-analyzer initialization options when using eglot. For example, one can use:

```elisp
(add-to-list
  'rustic-eglot-init-options
  (lambda ()
    (if (string-prefix-p "/home/sam/Dev/rust-clippy/"
                         (rustic-buffer-crate t))
        '(:rustcSource "discover"))))
```

and have rustic in eglot mode discover the compiler source location when working on Clippy.