### PR TITLE
[bugfix] call parent method in eglot-initialization-options

### DIFF
--- a/rustic-lsp.el
+++ b/rustic-lsp.el
@@ -133,12 +133,14 @@ with `lsp-rust-switch-server'."
 
   (cl-defmethod eglot-initialization-options ((server eglot-rust-analyzer))
     "Pass `detachedFiles' when `rustic-enable-detached-file-support' is non-`nil'."
-    (if (or (null rustic-enable-detached-file-support)
-            (null buffer-file-name)
-            (rustic-buffer-crate t))
-        eglot--{}
-      (list :detachedFiles
-            (vector (file-local-name (file-truename buffer-file-name))))))
+    (let ((base-initialization-options (cl-call-next-method)))
+      (if (or (null rustic-enable-detached-file-support)
+              (null buffer-file-name)
+              (rustic-buffer-crate t))
+          base-initialization-options
+        `(:detachedFiles
+          (vector (file-local-name (file-truename buffer-file-name)))
+          ,@base-initialization-options))))
 
   (rustic-setup-eglot))
 


### PR DESCRIPTION
`(eglot-initialization-options)` is a `cl-defgeneric` overridable method with a default implementation, and rustic-mode was overriding it but not calling the default implementation. 

This means that any core eglot logic around initialization options was failing to run, which had a user-visible consequence that the `initializationOptions` behaviour described in [the eglot manual](https://joaotavora.github.io/eglot/#User_002dspecific-configuration) was not happening.