### PR TITLE
Correctly handle directory on rerun

### DIFF
--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -195,7 +195,8 @@ When calling this function from `rustic-popup-mode', always use the value of
 (defun rustic-cargo-test-rerun ()
   "Run 'cargo test' with `rustic-test-arguments'."
   (interactive)
-  (rustic-cargo-test-run rustic-test-arguments))
+  (let ((default-directory (or rustic-compilation-directory default-directory)))
+    (rustic-cargo-test-run rustic-test-arguments)))
 
 ;;;###autoload
 (defun rustic-cargo-current-test ()
@@ -617,7 +618,8 @@ When calling this function from `rustic-popup-mode', always use the value of
 (defun rustic-cargo-run-rerun ()
   "Run 'cargo run' with `rustic-run-arguments'."
   (interactive)
-  (rustic-cargo-run-command rustic-run-arguments))
+  (let ((default-directory (or rustic-compilation-directory default-directory)))
+    (rustic-cargo-run-command rustic-run-arguments)))
 
 (defun rustic--get-run-arguments ()
   "Helper utility for getting arguments related to 'examples' directory."

--- a/rustic-compile.el
+++ b/rustic-compile.el
@@ -209,6 +209,9 @@ Error matching regexes from compile.el are removed."
 
 ;;; Compilation Process
 
+(defvar rustic-compilation-directory nil
+  "original directory for rust compilation process.")
+
 (defvar rustic-compilation-process-name "rustic-compilation-process"
   "Process name for rust compilation processes.")
 
@@ -249,6 +252,7 @@ Set environment variables for rust process."
   (let ((inhibit-read-only t))
     (with-current-buffer buf
       (erase-buffer)
+      (setq-local rustic-compilation-directory dir)
       (setq default-directory dir)
       (funcall mode)
       (unless no-mode-line


### PR DESCRIPTION
Currently rustic will override the `default-directory` to the workspace root after a compilation is finished. This enables it to correctly find the paths in error messages. But it also means that if you rerun a command it will rerun in the root crate instead of the original one.

This change adds a new variable to track the original directory and resets it when we rerun.