### PR TITLE
Use RUSTIC-CARGO-BIN in org babel code

### DIFF
--- a/rustic-babel.el
+++ b/rustic-babel.el
@@ -75,7 +75,7 @@ should be wrapped in which case we will disable rustfmt."
                            ((eq toolchain-kw-or-string 'stable) "+stable")
                            (toolchain-kw-or-string (format "+%s" toolchain-kw-or-string))
                            (t (format "+%s" rustic-babel-default-toolchain))))
-          (params (list "cargo" toolchain "build" "--quiet"))
+          (params (list (rustic-cargo-bin) toolchain "build" "--quiet"))
           (inhibit-read-only t))
      (rustic-compilation-setup-buffer err-buff dir 'rustic-compilation-mode)
      (when rustic-babel-display-compilation-buffer
@@ -126,7 +126,7 @@ execution with rustfmt."
 
            ;; run project
            (let* ((err-buff (get-buffer-create rustic-babel-compilation-buffer-name))
-                  (params (list "cargo" toolchain "run" "--quiet"))
+                  (params (list (rustic-cargo-bin) toolchain "run" "--quiet"))
                   (inhibit-read-only t))
              (rustic-make-process
               :name rustic-babel-process-name
@@ -215,7 +215,7 @@ after successful compilation."
 Return full path if EXPAND is t."
   (let* ((default-directory org-babel-temporary-directory)
          (dir (make-temp-file-internal "cargo" 0 "" nil)))
-    (shell-command-to-string (format "cargo new %s --bin --quiet" dir))
+    (shell-command-to-string (format "%s new %s --bin --quiet" (rustic-cargo-bin) dir))
     (if expand
         (concat (expand-file-name dir) "/")
       dir)))


### PR DESCRIPTION
If the "cargo" executable is not in the PATH, the org babel code will not work.  This was the case for me on macOS using rustup under Emacs.app, where the per-user PATH settings are not easily configured.