### PR TITLE
Unified Run Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,6 +531,28 @@ sent to the program in one of two ways:
   input can be typed directly into the output buffer of 'cargo run'
   and sent off with `RET`, just like in `comint-mode`.  You need
   [polymode](https://polymode.github.io) installed for this to work.
+  
+#### Run Arguments
+
+The run arguments of the `cargo run` command is determined by the 
+`rustic-run-arguments` variable.
+
+By default, any of the run commands will ask the user what the run arguments
+should be in the minibuffer and stored in the `rustic-run-arguments` variable. 
+However if the `rustic-cargo-use-last-stored-arguments` variable is set to a non
+`nil` value, the previously stored value of `rustic-run-arguments` would be used.
+
+An alternative way of specify the run arguments would be using the function
+arguments. If it is set to a non `nil` value the argument would be used and
+stored in `rustic-run-arguments` instead.
+
+For example:
+
+``` elisp
+(rustic-cargo-run "-r")
+```
+
+The `cargo run` would be run with the argument "-r".
 
 ### Outdated
 

--- a/rustic-cargo.el
+++ b/rustic-cargo.el
@@ -585,6 +585,14 @@ If BIN is not nil, create a binary application, otherwise a library."
 (define-derived-mode rustic-cargo-run-mode rustic-compilation-mode "cargo-run"
   :group 'rustic)
 
+(defun rustic-ask-run-args ()
+  "Asks the cargo run arguments for cargo run from the minibuffer.
+
+The run arguments is stored in rustic-run-arguments."
+  (interactive)
+  (setq rustic-run-arguments (read-from-minibuffer
+                              "Cargo run arguments: " rustic-run-arguments)))
+
 ;;;###autoload
 (defun rustic-cargo-run-command (&optional run-args)
   "Start compilation process for 'cargo run' with optional RUN-ARGS."
@@ -601,17 +609,23 @@ If BIN is not nil, create a binary application, otherwise a library."
 (defun rustic-cargo-run (&optional arg)
   "Run 'cargo run'.
 
+TODO: Auto specify example/bin based on file.
+
 If ARG is not nil, use value as argument and store it in `rustic-run-arguments'.
-When calling this function from `rustic-popup-mode', always use the value of
-`rustic-run-arguments'."
+
+When calling this function from `rustic-popup-mode' or
+`rustic-cargo-use-last-stored-arguments' is not nil, always use the value of
+`rustic-run-arguments'.
+
+Otherwise the arguments are taken from the minibuffer."
   (interactive "P")
   (rustic-cargo-run-command
-   (cond (arg
-          (setq rustic-run-arguments (read-from-minibuffer "Cargo run arguments: " rustic-run-arguments)))
+   (cond (arg (setq rustic-run-arguments arg))
+         ;; Using stored arguments
          (rustic-cargo-use-last-stored-arguments
           rustic-run-arguments)
-         ((rustic--get-run-arguments))
-         (t rustic-run-arguments))))
+         ;; Asking from minibuffer
+         (t (rustic-ask-run-args)))))
 
 ;;;###autoload
 (defun rustic-cargo-run-rerun ()

--- a/rustic-comint.el
+++ b/rustic-comint.el
@@ -91,12 +91,12 @@ Otherwise the arguments are taken from the minibuffer."
   "Make Cargo comint Repl in BUFFER.
 Optionally accepts RUN-ARGS which will be passed to the
 executable."
-  (make-comint-in-buffer
+  (apply 'make-comint-in-buffer
    rustic-run-comint-buffer-name
    buffer
    (rustic-cargo-bin)
    '()
-   run-args))
+   (split-string run-args)))
 
 ;;; Cargo run with plain comint and optional polymode
 


### PR DESCRIPTION
I have updated the run commands based on my suggestion in #517.

I also removed the feature where plain run will automatically add arguments if in example directory. A potential TODO item. I am thinking of some way of separating the arguments for `cargo run` and for the compiled binary into different variables. The user can then specify any additional arguments used for `cargo run` in the variable, while being able to test out their binary's arguments.

PS: I also fix a bug with comint run with any arguments other than an empty string.