### PR TITLE
Use more comfortable colors in ansi output

### DIFF
--- a/rustic-compile.el
+++ b/rustic-compile.el
@@ -116,10 +116,10 @@
   :group 'rustic-compilation)
 
 (defcustom rustic-ansi-faces ["black"
-                              "red3"
+                              "OrangeRed3"
                               "green3"
                               "yellow3"
-                              "blue2"
+                              "RoyalBlue3"
                               "magenta3"
                               "cyan3"
                               "white"]


### PR DESCRIPTION
### OrangeRed3 Example:
<img width="483" alt="Screenshot 2024-03-16 at 21 39 36" src="https://github.com/brotzeit/rustic/assets/1160419/00624695-84f4-4069-97ec-6faa7bf54f34">

### RoyalBlue3 Example:
<img width="478" alt="Screenshot 2024-03-16 at 21 38 59" src="https://github.com/brotzeit/rustic/assets/1160419/acc8dc61-c1e2-44da-8f34-e6188135bd33">
