### PR TITLE
Add unique test module scope for arg to 'cargo test'

### DIFF
--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -44,6 +44,24 @@ Emacs shutdown.")
     (should (rustic-compare-code-after-manip
              original point-pos manip-func expected (buffer-string)))))
 
+(cl-defun rustic-test-create-test-file (body &optional (test-file-path "main.rs"))
+  (let* ((project-dir (rustic-babel-generate-project t))
+         (full-test-file-path (concat project-dir "src/" test-file-path))
+         (file (expand-file-name full-test-file-path))
+         (file-dir (file-name-directory file))
+         (buffer (get-buffer-create "does-not-matter"))
+         (rustic-format-trigger nil))
+    ;; Ensure any intermediate directories exist, which may be the
+    ;; case with submodule setups
+    (if (not (file-directory-p file-dir))
+        (make-directory file-dir t))
+    (with-current-buffer buffer
+      (write-file file)
+      (insert "#[allow(non_snake_case)]")
+      (insert body)
+      (save-buffer)
+    buffer)))
+
 ;; TODO: rename
 (defun rustic-test-count-error-helper (string)
   (let* ((buffer (get-buffer-create "b"))


### PR DESCRIPTION
When rustic-cargo-current-test sees point at a test module's definition (or slightly below, while being above the first test function), then construct an argument for 'cargo test' that will run only that module's tests.

Since most test modules are not uniquely named, this means either prepending the parent module to the current module (e.g. when tests are in 'some_mod.rs', then 'cargo test some_mod::tests'), or if at crate root then using 'lib' or 'main' as the argument (e.g. when tests are in 'lib.rs', then 'cargo test lib').

Handle both module definition styles, either when modules are defined in a like-named file or living in a like-named directory in a file named 'mod.rs'.

This commit is feature complete, but only covers the scenario where tests are defined in the same file as production code.

Partially resolves brotzeit#561 (1-3).